### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/Unit Test Automation.yml
+++ b/.github/workflows/Unit Test Automation.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - develop
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/sashiksu/postal-code-checker/security/code-scanning/2](https://github.com/sashiksu/postal-code-checker/security/code-scanning/2)

Add an explicit `permissions` block at the workflow root (best here since there is only one job and no job-specific variation needed), setting the minimum required scope:

- `contents: read`

This preserves current behavior while documenting and enforcing least privilege.  
Edit **`.github/workflows/Unit Test Automation.yml`** by inserting the permissions block after the trigger section (`on:`...) and before `jobs:`.  
No imports, methods, or extra definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
