### PR TITLE
2.1.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 node_modules
 dist
+# Claude Code per-project settings (personal allow list, machine-local)
+.claude/settings.local.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ Adds a single-place configuration API that lets you override built-in country da
 
 ### SSR / multi-tenant note
 
-`configure()` is a module-level singleton. That matches how `i18next` and most config-at-boot packages work, and keeps the common-case DX trivial. Per-request configuration for SSR or multi-tenant servers isn't supported in this release — if you need it, [open an issue](https://github.com/sashiksu/postal-code-checker/issues/new) describing your use case and we'll consider a `createValidator()` factory for a future release.
+`configure()` is a module-level singleton: call it once at app boot and every downstream utility sees the merged dataset without extra wiring. Per-request configuration for SSR or multi-tenant servers isn't supported in this release — if you need it, [open an issue](https://github.com/sashiksu/postal-code-checker/issues/new) describing your use case and we'll consider a `createValidator()` factory for a future release.
 
 ### Demo
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,33 @@
 
 All notable changes to `postal-code-checker` are documented here. The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.1.0-alpha.2]
+
+Adds a single-place configuration API that lets you override built-in country data or add brand-new countries at runtime — every utility in the package honors the override. Backward-compatible with 2.1.0-alpha.1 and 2.0; no migration needed.
+
+### Added
+
+- **`configure(config)`** — register a user-supplied country dataset in one call, typically at app boot. Each entry either replaces a built-in country (when the alpha-2 key matches an existing one) or adds a brand-new country. Replace semantics per country — patterns are not merged field-by-field. Runtime validation throws `ConfigurationError` with a field-specific message on bad input (missing keys, malformed regex, non-uppercase codes, etc.). Calls are idempotent: each call starts from the bundled defaults and layers the given overrides on top, so prior calls don't accumulate.
+- **`resetConfig()`** — discards any active override and restores the bundled defaults. Designed for test teardown (`afterEach`), scenario switching in demos, and HMR during development.
+- **`ConfigurationError`** class — thrown by `configure()` on validation failure. Exported so consumers can `catch (err) { if (err instanceof ConfigurationError) … }`.
+- **`PostalCodeConfig`** and **`AnyCountryCode`** types exported from the package barrel. `PostalCodeConfig` describes the shape `configure()` accepts; `AnyCountryCode` is `CountryCode | (string & {})` and preserves autocomplete for known countries while accepting any string for runtime-added codes.
+- **Kosovo (XK) as the reference example.** Kosovo is the canonical "country the default dataset doesn't cover" case — it's not in ISO 3166-1, so Google's libaddressinput doesn't ship it, but it has a working 5-digit postal code system and is used as `XK` by most shipping APIs. The docs and demo walk through registering it.
+
+### Changed
+
+- **Every existing utility now reads through a single active-data accessor.** `validatePostalCode`, `validatePostalCodes`, `getCountryByCode`, `getAllCountries`, `guessCountries`, and `format` all see the merged dataset after `configure()` is called. No call-site changes required.
+- **Public country-code input type widened to `AnyCountryCode`.** Runtime behavior is unchanged. The narrow `CountryCode` union is still exported for users who want strict typing against known alpha-2 codes. The one theoretical break: code that assigned `getCountryByCode(...).countryCode` back to a `CountryCode`-typed variable now needs either `AnyCountryCode` or a cast.
+
+### SSR / multi-tenant note
+
+`configure()` is a module-level singleton. That matches how `i18next` and most config-at-boot packages work, and keeps the common-case DX trivial. Per-request configuration for SSR or multi-tenant servers isn't supported in this release — if you need it, [open an issue](https://github.com/sashiksu/postal-code-checker/issues/new) describing your use case and we'll consider a `createValidator()` factory for a future release.
+
+### Demo
+
+- New **Configuration** tab with an editable JSON textarea seeded with the Kosovo example, Apply/Reset buttons, and a live validator that updates in place as the config changes.
+- The Reset button includes a short note explaining *when* you'd use `resetConfig()` — test teardown, scenario switching, HMR.
+- Shareable URL encoding the current config in the page hash, so a config can be linked to colleagues without copy-pasting JSON.
+
 ## [2.1.0-alpha.1]
 
 Adds two new public APIs for working with postal codes that are valid across countries. Backward-compatible with 2.0; no migration needed.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,16 +2,18 @@
 
 All notable changes to `postal-code-checker` are documented here. The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [2.1.0-alpha.2]
+## [2.1.0]
 
-Adds a single-place configuration API that lets you override built-in country data or add brand-new countries at runtime — every utility in the package honors the override. Backward-compatible with 2.1.0-alpha.1 and 2.0; no migration needed.
+Adds three new public APIs built on the existing 2.0 dataset: `format()` returns the canonical storable form of a postal code, `guessCountries()` lists every country whose pattern accepts an input, and `configure()` + `resetConfig()` let you override built-in country data or register brand-new countries at runtime — every utility in the package honors the override. Backward-compatible with 2.0; no migration needed.
 
 ### Added
 
+- **`format(countryCode, postalCode)`** — returns the canonical form of a valid code (trimmed, uppercased), ready to store in a database. Returns `null` when the input doesn't match the country's pattern or the country has no postal code system. Accepts alpha-2 and alpha-3 country codes.
+- **`guessCountries(postalCode)`** — given a postal code with no country context, returns every country whose pattern accepts the input. Result is `{ countryName, countryCode }[]` sorted alphabetically by `countryName` — ready to render as a picker. Countries with no postal code system are naturally excluded.
 - **`configure(config)`** — register a user-supplied country dataset in one call, typically at app boot. Each entry either replaces a built-in country (when the alpha-2 key matches an existing one) or adds a brand-new country. Replace semantics per country — patterns are not merged field-by-field. Runtime validation throws `ConfigurationError` with a field-specific message on bad input (missing keys, malformed regex, non-uppercase codes, etc.). Calls are idempotent: each call starts from the bundled defaults and layers the given overrides on top, so prior calls don't accumulate.
 - **`resetConfig()`** — discards any active override and restores the bundled defaults. Designed for test teardown (`afterEach`), scenario switching in demos, and HMR during development.
 - **`ConfigurationError`** class — thrown by `configure()` on validation failure. Exported so consumers can `catch (err) { if (err instanceof ConfigurationError) … }`.
-- **`PostalCodeConfig`** and **`AnyCountryCode`** types exported from the package barrel. `PostalCodeConfig` describes the shape `configure()` accepts; `AnyCountryCode` is `CountryCode | (string & {})` and preserves autocomplete for known countries while accepting any string for runtime-added codes.
+- **`PostalCodeConfig`, `AnyCountryCode`, and `CountryOption`** types exported from the package barrel. `PostalCodeConfig` describes the shape `configure()` accepts; `AnyCountryCode` is `CountryCode | (string & {})` and preserves autocomplete for known countries while accepting any string for runtime-added codes; `CountryOption` is the return shape of both `getAllCountries` and `guessCountries`.
 - **Kosovo (XK) as the reference example.** Kosovo is the canonical "country the default dataset doesn't cover" case — it's not in ISO 3166-1, so Google's libaddressinput doesn't ship it, but it has a working 5-digit postal code system and is used as `XK` by most shipping APIs. The docs and demo walk through registering it.
 
 ### Changed
@@ -25,25 +27,11 @@ Adds a single-place configuration API that lets you override built-in country da
 
 ### Demo
 
+- Interactive `format()` and `guessCountries()` panels in the Playground section, plus new "Format" and "Guess" tabs in the Code Examples.
 - New **Configuration** tab with an editable JSON textarea seeded with the Kosovo example, Apply/Reset buttons, and a live validator that updates in place as the config changes.
 - The Reset button includes a short note explaining *when* you'd use `resetConfig()` — test teardown, scenario switching, HMR.
 - Shareable URL encoding the current config in the page hash, so a config can be linked to colleagues without copy-pasting JSON.
-
-## [2.1.0-alpha.1]
-
-Adds two new public APIs for working with postal codes that are valid across countries. Backward-compatible with 2.0; no migration needed.
-
-### Added
-
-- **`format(countryCode, postalCode)`** — returns the canonical form of a valid code (trimmed, uppercased), ready to store in a database. Returns `null` when the input doesn't match the country's pattern or the country has no postal code system. Accepts alpha-2 and alpha-3 country codes.
-- **`guessCountries(postalCode)`** — given a postal code with no country context, returns every country whose pattern accepts the input. Result is `{ countryName, countryCode }[]` sorted alphabetically by `countryName` — ready to render as a picker. Countries with no postal code system are naturally excluded.
-- **`CountryOption` type re-exported** from the package barrel. Previously internal; both `getAllCountries` and the new `guessCountries` return `CountryOption[]`, so consumers now have access to the shape.
-
-### Demo
-
-- Interactive `format()` and `guessCountries()` panels in the Playground section.
-- New "Format" and "Guess" tabs in the Code Examples.
-- Roadmap no longer lists either function as planned; both now ship with 2.1.
+- Roadmap trimmed — `format()`, `guessCountries()`, and `configure()` no longer appear as planned work; all three ship in this release.
 
 ## [2.0.1]
 

--- a/README.md
+++ b/README.md
@@ -205,6 +205,43 @@ Returns the full country record (patterns, example codes, name, 2-letter code) o
 
 Returns `{ countryName, countryCode }[]` for every supported country, sorted alphabetically.
 
+### `configure(config): void` — _new in 2.1_
+
+Registers a user-supplied country dataset in one call, typically at app boot. Each entry either replaces a built-in country (when the alpha-2 key matches) or adds a brand-new country. Every utility in the package honors the override immediately — no call-site changes needed.
+
+```ts
+import { configure, validatePostalCode } from "postal-code-checker";
+
+configure({
+  countries: {
+    // Kosovo — not in ISO 3166-1, so not in the bundled dataset
+    XK: {
+      patterns: ["/^(?:[1-7]\\d{4})$/"],
+      example: ["10000", "20000"],
+      country: "Kosovo",
+      alpha3: "XKX",
+    },
+  },
+});
+
+validatePostalCode("XK", "10000");  // → true
+validatePostalCode("XKX", "10000"); // → true (alpha-3 works)
+```
+
+Replace semantics per country, idempotent across calls, and a fail-fast `ConfigurationError` on bad input. Full guide: [`docs/CONFIGURATION.md`](./docs/CONFIGURATION.md).
+
+> **SSR / multi-tenant:** `configure()` is a module-level singleton and isn't designed for per-request overrides. If you need that, [open an issue](https://github.com/sashiksu/postal-code-checker/issues/new) describing your use case.
+
+### `resetConfig(): void` — _new in 2.1_
+
+Discards any active `configure()` override and restores the bundled defaults. Primary use cases: test teardown (`afterEach(resetConfig)`), scenario switching, HMR.
+
+```ts
+afterEach(() => {
+  resetConfig();
+});
+```
+
 ### `usePostalCodeValidation()` — _deprecated since 1.1.0_
 
 Retained for backward compatibility; delegates to the top-level `validatePostalCode`. Kept functional in 2.x; scheduled for removal in 3.0. Prefer the top-level exports in new code.
@@ -216,12 +253,27 @@ Retained for backward compatibility; delegates to the top-level `validatePostalC
 ```typescript
 type CountryCode = string; // ISO 3166-1 alpha-2 ("US") or alpha-3 ("USA")
 
+type AnyCountryCode = CountryCode | (string & {});
+// preserves autocomplete for known codes while accepting runtime-added ones
+
 type Country = {
   postalCodePatterns: string[];  // regex strings wrapped in slashes, e.g. "/^\\d{5}$/"
   examplePostalCodes: string[];
   isGenericRegex: boolean;
   countryName: string;
-  countryCode: CountryCode;
+  countryCode: AnyCountryCode;
+};
+
+// Shape accepted by configure()
+type PostalCodeConfig = {
+  countries: {
+    [countryCode: string]: {
+      patterns: string[];   // each entry wrapped in slashes, e.g. "/^\\d{5}$/"
+      example: string[];
+      country: string;
+      alpha3?: string;      // optional 3-letter uppercase alpha-3 code
+    };
+  };
 };
 ```
 
@@ -279,6 +331,7 @@ The `usePostalCodeValidation` name followed React's hook naming convention, whic
 
 ### ✅ Shipped
 
+- `configure()` + `resetConfig()` — user-supplied country overrides and brand-new countries via a single-place config _(2.1.0)_
 - `format()` — canonical storable form, or `null` if invalid _(2.1.0)_
 - `guessCountries()` — countries whose pattern accepts an input _(2.1.0)_
 - Swap data source to Google `libaddressinput` _(2.0.0)_
@@ -293,8 +346,8 @@ The `usePostalCodeValidation` name followed React's hook naming convention, whic
 
 ### 🔜 Planned
 
-- Accept user-supplied country data to override / merge the bundled dataset
 - Subdivision-level validation (Google's `sub_zips` prefix data)
+- `createValidator()` factory for SSR / multi-tenant use cases (if demand shows up)
 - Removal of deprecated `usePostalCodeValidation` _(3.0.0)_
 
 ---

--- a/README.md
+++ b/README.md
@@ -10,8 +10,18 @@
 [![license](https://img.shields.io/npm/l/postal-code-checker.svg)](./LICENSE)
 
 <p align="center">
-  <img src="https://raw.githubusercontent.com/sashiksu/postal-code-checker/master/docs/hero.gif" alt="Validating postal codes for 249 countries in real time" width="720" />
+  <img src="https://raw.githubusercontent.com/sashiksu/postal-code-checker/master/docs/hero.gif" alt="Validating postal codes for 249 countries in real time" width="480" />
 </p>
+
+**Prefer to try before installing?**
+
+<p align="center">
+  <a href="https://sashiksu.github.io/postal-code-checker/">
+    <img src="https://img.shields.io/badge/%F0%9F%9A%80%20%20Launch%20the%20Live%20Demo-171717?style=for-the-badge&labelColor=171717&color=ff6b35" alt="Launch the Live Demo" height="56" />
+  </a>
+</p>
+
+Browse the full 249-country dataset, run single and batch validations, and edit live code right in the browser — no install required.
 
 Powered by Google's [`libaddressinput`](https://github.com/google/libaddressinput) — the same dataset behind Chromium, Android, and Google Pay address forms.
 
@@ -50,16 +60,6 @@ validatePostalCodes("US", ["12345", "oops"]); // → [true, false]
 ```
 
 Works in **React, Next.js, Vue, Svelte, Angular, Node.js, Deno, Bun, and plain browser JS** — no framework assumptions.
-
-**Prefer to try before installing?**
-
-<p align="center">
-  <a href="https://sashiksu.github.io/postal-code-checker/">
-    <img src="https://img.shields.io/badge/%F0%9F%9A%80%20Launch%20the%20Live%20Demo-171717?style=for-the-badge" alt="Launch the Live Demo" height="44" />
-  </a>
-</p>
-
-Browse the full 249-country dataset, run single and batch validations, and edit live code right in the browser — no install required.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -53,12 +53,13 @@ Works in **React, Next.js, Vue, Svelte, Angular, Node.js, Deno, Bun, and plain b
 
 **Prefer to try before installing?**
 
-👉 **[Live interactive demo](https://sashiksu.github.io/postal-code-checker/)** — browse the dataset, run single + batch validations, edit code in the browser.
+<p align="center">
+  <a href="https://sashiksu.github.io/postal-code-checker/">
+    <img src="https://img.shields.io/badge/%F0%9F%9A%80%20Launch%20the%20Live%20Demo-171717?style=for-the-badge" alt="Launch the Live Demo" height="44" />
+  </a>
+</p>
 
-[![Try on RunKit](https://img.shields.io/badge/try_on-runkit-491757?style=flat&labelColor=171717)](https://npm.runkit.com/postal-code-checker)
-[![Open in StackBlitz](https://img.shields.io/badge/open_in-stackblitz-1389FD?style=flat&labelColor=171717)](https://stackblitz.com/fork/github/sashiksu/postal-code-checker)
-
-RunKit spins up a Node.js REPL with the package preloaded. StackBlitz forks the full repo and opens it in a web IDE — good for exploring the source.
+Browse the full 249-country dataset, run single and batch validations, and edit live code right in the browser — no install required.
 
 ---
 

--- a/demo/src/App.tsx
+++ b/demo/src/App.tsx
@@ -2,6 +2,7 @@ import { useCallback, useRef, useState } from "react";
 import { Navbar } from "./components/Navbar";
 import { Sidebar } from "./components/Sidebar";
 import { Hero } from "./components/Hero";
+import { CustomCountryCta } from "./components/CustomCountryCta";
 import { WhyChoose } from "./components/WhyChoose";
 import { InstallMatrix } from "./components/InstallMatrix";
 import { CodeExamples } from "./components/CodeExamples";
@@ -50,6 +51,7 @@ export function App() {
         <Sidebar />
         <main id="main">
           <Hero countryCode={countryCode} onCountryChange={setCountryCode} />
+          <CustomCountryCta />
           <WhyChoose />
           <InstallMatrix />
           <CodeExamples />

--- a/demo/src/components/BatchPanel.module.scss
+++ b/demo/src/components/BatchPanel.module.scss
@@ -10,6 +10,14 @@
   display: flex;
   flex-direction: column;
   height: 520px;
+  position: relative;
+}
+
+.shareCorner {
+  position: absolute;
+  top: 14px;
+  right: 14px;
+  z-index: 1;
 }
 
 .header {

--- a/demo/src/components/BatchPanel.tsx
+++ b/demo/src/components/BatchPanel.tsx
@@ -1,13 +1,33 @@
-import { useMemo, useState } from "react";
+import { useCallback, useMemo, useState } from "react";
 import { validatePostalCodes } from "postal-code-checker";
+import { readShareParam } from "../data/share";
 import { CountryCombobox } from "./ui/CountryCombobox";
+import { ShareButton } from "./ui/ShareButton";
 import styles from "./BatchPanel.module.scss";
 
 const DEFAULT_BATCH = ["K1A 0T6", "90210", "BAD-CODE", "SW1A 1AA"].join("\n");
 
+type Shared = { country: string; codes: string };
+
+function loadInitial(): Shared {
+  const raw = readShareParam("batch");
+  if (raw) {
+    try {
+      const parsed = JSON.parse(raw) as Partial<Shared>;
+      if (typeof parsed.country === "string" && typeof parsed.codes === "string") {
+        return { country: parsed.country, codes: parsed.codes };
+      }
+    } catch {
+      // fall through to defaults
+    }
+  }
+  return { country: "CA", codes: DEFAULT_BATCH };
+}
+
 export function BatchPanel() {
-  const [countryCode, setCountryCode] = useState("CA");
-  const [raw, setRaw] = useState(DEFAULT_BATCH);
+  const initial = useMemo(loadInitial, []);
+  const [countryCode, setCountryCode] = useState(initial.country);
+  const [raw, setRaw] = useState(initial.codes);
 
   const lines = useMemo(
     () => raw.split("\n").map((l) => l.trim()).filter(Boolean),
@@ -22,8 +42,16 @@ export function BatchPanel() {
   const validCount = results.filter(Boolean).length;
   const total = results.length;
 
+  const getShareValue = useCallback(
+    () => JSON.stringify({ country: countryCode, codes: raw }),
+    [countryCode, raw],
+  );
+
   return (
     <div className={styles.panel}>
+      <div className={styles.shareCorner}>
+        <ShareButton paramName="batch" getValue={getShareValue} ariaLabel="Share this batch example" />
+      </div>
       <div className={styles.header}>
         <div>
           <h3>Batch validation</h3>

--- a/demo/src/components/CodeExamples.module.scss
+++ b/demo/src/components/CodeExamples.module.scss
@@ -10,6 +10,14 @@
   border-radius: $radius-lg;
   padding: 28px;
   box-shadow: var(--shadow-sm);
+  position: relative;
+}
+
+.shareCorner {
+  position: absolute;
+  top: 14px;
+  right: 14px;
+  z-index: 1;
 }
 
 .header {

--- a/demo/src/components/CodeExamples.tsx
+++ b/demo/src/components/CodeExamples.tsx
@@ -1,21 +1,38 @@
-import { useMemo, useState } from "react";
+import { useCallback, useMemo, useState } from "react";
 import { EXAMPLES, type ExampleId } from "../data/examples";
+import { readShareParam } from "../data/share";
 import { CodeBlock } from "./ui/CodeBlock";
+import { ShareButton } from "./ui/ShareButton";
 import { Tabs } from "./ui/Tabs";
 import styles from "./CodeExamples.module.scss";
 
 const TABS = EXAMPLES.map((e) => ({ id: e.id, label: e.label }));
+const VALID_IDS = new Set<string>(EXAMPLES.map((e) => e.id));
+
+function loadInitial(): ExampleId {
+  const raw = readShareParam("examples");
+  if (raw && VALID_IDS.has(raw)) return raw as ExampleId;
+  return "basic";
+}
 
 export function CodeExamples() {
-  const [active, setActive] = useState<ExampleId>("basic");
+  const [active, setActive] = useState<ExampleId>(() => loadInitial());
   const current = useMemo(
     () => EXAMPLES.find((e) => e.id === active) ?? EXAMPLES[0],
     [active],
   );
+  const getShareValue = useCallback(() => active, [active]);
 
   return (
     <section id="examples" className={styles.section} aria-labelledby="examples-heading">
       <div className={styles.panel}>
+        <div className={styles.shareCorner}>
+          <ShareButton
+            paramName="examples"
+            getValue={getShareValue}
+            ariaLabel="Share this example"
+          />
+        </div>
         <div className={styles.header}>
           <h2 id="examples-heading">Code examples</h2>
           <Tabs

--- a/demo/src/components/ConfigurationPanel.module.scss
+++ b/demo/src/components/ConfigurationPanel.module.scss
@@ -40,40 +40,6 @@
   }
 }
 
-.intro {
-  display: grid;
-  grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
-  gap: 24px;
-  align-items: start;
-  margin-bottom: 18px;
-  padding-right: 44px; // leave room for the absolute share corner
-
-  @include below-lg {
-    grid-template-columns: 1fr;
-    gap: 16px;
-    padding-right: 0;
-  }
-}
-
-.introCopy {
-  min-width: 0;
-
-  h3 {
-    margin: 0;
-    font-size: 15px;
-    font-weight: 600;
-    letter-spacing: -0.01em;
-  }
-
-  p {
-    margin: 6px 0 0;
-    font-size: 13px;
-    line-height: 1.6;
-    color: var(--color-muted);
-    max-width: 60ch;
-  }
-}
-
 .editorActions {
   display: flex;
   flex-wrap: wrap;
@@ -119,7 +85,7 @@
 }
 
 .wiringBlock {
-  margin: 0;
+  margin: 0 0 16px;
   min-width: 0;
 }
 

--- a/demo/src/components/ConfigurationPanel.module.scss
+++ b/demo/src/components/ConfigurationPanel.module.scss
@@ -40,6 +40,40 @@
   }
 }
 
+.intro {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
+  gap: 24px;
+  align-items: start;
+  margin-bottom: 18px;
+  padding-right: 44px; // leave room for the absolute share corner
+
+  @include below-lg {
+    grid-template-columns: 1fr;
+    gap: 16px;
+    padding-right: 0;
+  }
+}
+
+.introCopy {
+  min-width: 0;
+
+  h3 {
+    margin: 0;
+    font-size: 15px;
+    font-weight: 600;
+    letter-spacing: -0.01em;
+  }
+
+  p {
+    margin: 6px 0 0;
+    font-size: 13px;
+    line-height: 1.6;
+    color: var(--color-muted);
+    max-width: 60ch;
+  }
+}
+
 .editorActions {
   display: flex;
   flex-wrap: wrap;
@@ -85,7 +119,8 @@
 }
 
 .wiringBlock {
-  margin: 0 0 16px;
+  margin: 0;
+  min-width: 0;
 }
 
 .wiringIntro {
@@ -103,10 +138,20 @@
   }
 
   span {
-    font-size: 13px;
+    font-size: 12.5px;
     line-height: 1.55;
     color: var(--color-muted);
-    max-width: 72ch;
+    max-width: 60ch;
+  }
+
+  code {
+    font-family: $font-mono;
+    font-size: 11.5px;
+    padding: 0 4px;
+    border-radius: 3px;
+    background: var(--color-panel-2);
+    border: 1px solid var(--color-border);
+    color: var(--color-text);
   }
 }
 

--- a/demo/src/components/ConfigurationPanel.module.scss
+++ b/demo/src/components/ConfigurationPanel.module.scss
@@ -86,29 +86,6 @@
 
 .wiringBlock {
   margin: 0 0 16px;
-  padding: 14px 14px 12px;
-  border: 1px solid var(--color-border);
-  background: var(--color-panel-2);
-  border-radius: $radius;
-}
-
-.wiringIntro {
-  display: flex;
-  flex-direction: column;
-  gap: 2px;
-  margin-bottom: 10px;
-
-  strong {
-    font-size: 13px;
-    font-weight: 600;
-    color: var(--color-text);
-    letter-spacing: -0.01em;
-  }
-
-  span {
-    font-size: 12.5px;
-    color: var(--color-muted);
-  }
 }
 
 .steps {

--- a/demo/src/components/ConfigurationPanel.module.scss
+++ b/demo/src/components/ConfigurationPanel.module.scss
@@ -7,6 +7,14 @@
   border-radius: $radius-lg;
   padding: 22px;
   box-shadow: var(--shadow-sm);
+  position: relative;
+}
+
+.shareCorner {
+  position: absolute;
+  top: 14px;
+  right: 14px;
+  z-index: 1;
 }
 
 .header {
@@ -28,14 +36,16 @@
     margin: 4px 0 0;
     font-size: 13px;
     color: var(--color-muted);
-    max-width: 62ch;
+    max-width: 72ch;
   }
 }
 
-.actions {
+.editorActions {
   display: flex;
-  gap: 8px;
   flex-wrap: wrap;
+  gap: 8px;
+  align-items: center;
+  padding: 10px 0 2px;
 }
 
 .button {
@@ -72,6 +82,93 @@
     background: var(--color-accent-hover, var(--color-accent));
     border-color: var(--color-accent-hover, var(--color-accent));
   }
+}
+
+.wiringBlock {
+  margin: 0 0 16px;
+  padding: 14px 14px 12px;
+  border: 1px solid var(--color-border);
+  background: var(--color-panel-2);
+  border-radius: $radius;
+}
+
+.wiringIntro {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  margin-bottom: 10px;
+
+  strong {
+    font-size: 13px;
+    font-weight: 600;
+    color: var(--color-text);
+    letter-spacing: -0.01em;
+  }
+
+  span {
+    font-size: 12.5px;
+    color: var(--color-muted);
+  }
+}
+
+.steps {
+  list-style: none;
+  margin: 0 0 18px;
+  padding: 0;
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 10px;
+
+  @include below-lg {
+    grid-template-columns: 1fr 1fr;
+  }
+
+  @media (max-width: 520px) {
+    grid-template-columns: 1fr;
+  }
+
+  li {
+    display: flex;
+    align-items: flex-start;
+    gap: 10px;
+    padding: 12px;
+    background: var(--color-panel-2);
+    border: 1px solid var(--color-border);
+    border-radius: $radius;
+    font-size: 12.5px;
+    line-height: 1.55;
+    color: var(--color-muted);
+  }
+
+  strong {
+    color: var(--color-text);
+    font-weight: 600;
+  }
+
+  code {
+    font-family: $font-mono;
+    font-size: 11.5px;
+    padding: 1px 4px;
+    border-radius: 3px;
+    background: var(--color-panel);
+    border: 1px solid var(--color-border);
+    color: var(--color-text);
+  }
+}
+
+.stepNum {
+  flex: 0 0 auto;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 22px;
+  height: 22px;
+  border-radius: 999px;
+  font-family: $font-mono;
+  font-size: 11.5px;
+  font-weight: 700;
+  background: var(--color-accent);
+  color: var(--color-accent-contrast);
 }
 
 .grid {

--- a/demo/src/components/ConfigurationPanel.module.scss
+++ b/demo/src/components/ConfigurationPanel.module.scss
@@ -88,6 +88,28 @@
   margin: 0 0 16px;
 }
 
+.wiringIntro {
+  display: grid;
+  gap: 4px;
+  margin-bottom: 8px;
+
+  strong {
+    font-family: $font-mono;
+    font-size: 11.5px;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+    color: var(--color-muted);
+    font-weight: 600;
+  }
+
+  span {
+    font-size: 13px;
+    line-height: 1.55;
+    color: var(--color-muted);
+    max-width: 72ch;
+  }
+}
+
 .steps {
   list-style: none;
   margin: 0 0 18px;
@@ -224,7 +246,7 @@
   border: 1px solid var(--color-accent-soft);
   border-radius: $radius;
   font-size: 12.5px;
-  color: var(--color-accent-contrast);
+  color: var(--color-accent);
 }
 
 .right {
@@ -368,7 +390,7 @@
   color: var(--color-text);
 
   strong {
-    color: var(--color-accent-contrast);
+    color: var(--color-accent);
   }
 }
 

--- a/demo/src/components/ConfigurationPanel.module.scss
+++ b/demo/src/components/ConfigurationPanel.module.scss
@@ -1,0 +1,315 @@
+@use "../styles/variables" as *;
+@use "../styles/mixins" as *;
+
+.panel {
+  background: var(--color-panel);
+  border: 1px solid var(--color-border);
+  border-radius: $radius-lg;
+  padding: 22px;
+  box-shadow: var(--shadow-sm);
+}
+
+.header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 16px;
+  margin-bottom: 14px;
+  flex-wrap: wrap;
+
+  h3 {
+    margin: 0;
+    font-size: 15px;
+    font-weight: 600;
+    letter-spacing: -0.01em;
+  }
+
+  p {
+    margin: 4px 0 0;
+    font-size: 13px;
+    color: var(--color-muted);
+    max-width: 62ch;
+  }
+}
+
+.actions {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.button {
+  font-family: $font-sans;
+  font-size: 12.5px;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  padding: 7px 14px;
+  border-radius: $radius;
+  border: 1px solid var(--color-border);
+  background: var(--color-panel-2);
+  color: var(--color-text);
+  cursor: pointer;
+  transition: background $duration-fast $ease, border-color $duration-fast $ease,
+    color $duration-fast $ease;
+
+  &:hover {
+    border-color: var(--color-accent);
+  }
+
+  &:focus-visible {
+    outline: none;
+    border-color: var(--color-accent);
+    box-shadow: 0 0 0 3px var(--color-accent-soft);
+  }
+}
+
+.apply {
+  background: var(--color-accent);
+  color: var(--color-accent-contrast);
+  border-color: var(--color-accent);
+
+  &:hover {
+    background: var(--color-accent-hover, var(--color-accent));
+    border-color: var(--color-accent-hover, var(--color-accent));
+  }
+}
+
+.grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 16px;
+
+  @include below-lg {
+    grid-template-columns: 1fr;
+  }
+}
+
+.editorWrap {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.paneLabel {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  font-family: $font-mono;
+  font-size: 11.5px;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--color-muted);
+}
+
+.textarea {
+  width: 100%;
+  box-sizing: border-box;
+  background: var(--color-panel-2);
+  border: 1px solid var(--color-border);
+  border-radius: $radius;
+  color: var(--color-text);
+  font-family: $font-mono;
+  font-size: 13px;
+  line-height: 1.55;
+  padding: 12px;
+  min-height: 320px;
+  resize: vertical;
+  tab-size: 2;
+  transition: border-color $duration-fast $ease, box-shadow $duration-fast $ease;
+
+  &:focus {
+    outline: none;
+    border-color: var(--color-accent);
+    box-shadow: 0 0 0 3px var(--color-accent-soft);
+  }
+
+  &[data-state="error"] {
+    border-color: var(--color-error);
+    box-shadow: 0 0 0 3px rgba(224, 77, 77, 0.12);
+  }
+}
+
+.errorBanner {
+  margin-top: 0;
+  padding: 10px 12px;
+  background: rgba(224, 77, 77, 0.08);
+  border: 1px solid rgba(224, 77, 77, 0.28);
+  border-radius: $radius;
+  font-size: 12.5px;
+  color: var(--color-error);
+  font-family: $font-mono;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+.appliedBanner {
+  margin-top: 0;
+  padding: 10px 12px;
+  background: var(--color-accent-soft);
+  border: 1px solid var(--color-accent-soft);
+  border-radius: $radius;
+  font-size: 12.5px;
+  color: var(--color-accent-contrast);
+}
+
+.right {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.card {
+  border: 1px solid var(--color-border);
+  background: var(--color-panel-2);
+  border-radius: $radius;
+  padding: 14px 14px 12px;
+}
+
+.cardTitle {
+  margin: 0 0 8px;
+  font-size: 11.5px;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--color-muted);
+}
+
+.diffRow {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 6px 0;
+  font-family: $font-mono;
+  font-size: 13px;
+
+  & + & {
+    border-top: 1px dashed var(--color-border);
+  }
+}
+
+.tag {
+  display: inline-flex;
+  align-items: center;
+  padding: 2px 8px;
+  font-family: $font-sans;
+  font-size: 10.5px;
+  font-weight: 700;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  border-radius: 999px;
+
+  &.added {
+    background: rgba(56, 161, 105, 0.14);
+    color: #1f7a49;
+  }
+
+  &.replaced {
+    background: rgba(214, 158, 46, 0.16);
+    color: #8a6b12;
+  }
+
+  &.bundled {
+    background: var(--color-panel);
+    color: var(--color-muted);
+    border: 1px solid var(--color-border);
+  }
+}
+
+.diffNone {
+  margin: 0;
+  font-size: 13px;
+  color: var(--color-muted);
+}
+
+.validatorRow {
+  display: grid;
+  grid-template-columns: 88px 1fr auto;
+  gap: 10px;
+  align-items: center;
+  font-family: $font-mono;
+  font-size: 13px;
+}
+
+.validatorLabel {
+  font-family: $font-sans;
+  font-size: 11.5px;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--color-muted);
+}
+
+.input {
+  width: 100%;
+  box-sizing: border-box;
+  background: var(--color-panel);
+  border: 1px solid var(--color-border);
+  border-radius: $radius;
+  color: var(--color-text);
+  font-family: $font-mono;
+  font-size: 13px;
+  padding: 8px 10px;
+
+  &:focus {
+    outline: none;
+    border-color: var(--color-accent);
+    box-shadow: 0 0 0 3px var(--color-accent-soft);
+  }
+}
+
+.status {
+  font-family: $font-sans;
+  font-size: 10.5px;
+  font-weight: 700;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  padding: 2px 8px;
+  border-radius: 999px;
+
+  &.ok {
+    color: #1f7a49;
+    background: rgba(56, 161, 105, 0.14);
+  }
+
+  &.bad {
+    color: var(--color-error);
+    background: rgba(224, 77, 77, 0.12);
+  }
+}
+
+.guessList {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.chip {
+  font-family: $font-mono;
+  font-size: 12px;
+  padding: 3px 8px;
+  border-radius: 999px;
+  background: var(--color-panel);
+  border: 1px solid var(--color-border);
+  color: var(--color-text);
+
+  strong {
+    color: var(--color-accent-contrast);
+  }
+}
+
+.note {
+  margin: 0;
+  font-size: 12.5px;
+  line-height: 1.55;
+  color: var(--color-muted);
+
+  code {
+    font-family: $font-mono;
+    font-size: 12px;
+    padding: 1px 5px;
+    border-radius: 4px;
+    background: var(--color-panel);
+    border: 1px solid var(--color-border);
+  }
+}

--- a/demo/src/components/ConfigurationPanel.tsx
+++ b/demo/src/components/ConfigurationPanel.tsx
@@ -1,0 +1,322 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import {
+  COUNTRIES,
+  ConfigurationError,
+  configure,
+  getCountryByCode,
+  guessCountries,
+  resetConfig,
+  validatePostalCode,
+  type PostalCodeConfig,
+} from "postal-code-checker";
+import styles from "./ConfigurationPanel.module.scss";
+
+const DEFAULT_CONFIG_JSON = `{
+  "countries": {
+    "XK": {
+      "patterns": ["/^(?:[1-7]\\\\d{4})$/"],
+      "example": ["10000", "20000"],
+      "country": "Kosovo",
+      "alpha3": "XKX"
+    },
+    "US": {
+      "patterns": ["/^(?:\\\\d{5}-\\\\d{4})$/"],
+      "example": ["12345-6789"],
+      "country": "United States"
+    }
+  }
+}
+`;
+
+type DiffEntry = {
+  code: string;
+  kind: "added" | "replaced";
+  country: string;
+};
+
+type AppliedState =
+  | { kind: "idle" }
+  | { kind: "applied"; diff: DiffEntry[]; at: number }
+  | { kind: "reset"; at: number };
+
+function encodeConfigToHash(text: string): string {
+  try {
+    return "#config=" + btoa(unescape(encodeURIComponent(text)));
+  } catch {
+    return "";
+  }
+}
+
+function decodeConfigFromHash(): string | null {
+  const hash = window.location.hash;
+  if (!hash.startsWith("#config=")) return null;
+  try {
+    const raw = hash.slice("#config=".length);
+    return decodeURIComponent(escape(atob(raw)));
+  } catch {
+    return null;
+  }
+}
+
+function computeDiff(config: PostalCodeConfig): DiffEntry[] {
+  const entries: DiffEntry[] = [];
+  for (const [code, entry] of Object.entries(config.countries ?? {})) {
+    if (!entry) continue;
+    entries.push({
+      code,
+      kind: COUNTRIES[code as keyof typeof COUNTRIES] ? "replaced" : "added",
+      country: entry.country,
+    });
+  }
+  return entries.sort((a, b) => a.code.localeCompare(b.code));
+}
+
+export function ConfigurationPanel() {
+  const [text, setText] = useState<string>(
+    () => decodeConfigFromHash() ?? DEFAULT_CONFIG_JSON,
+  );
+  const [error, setError] = useState<string | null>(null);
+  const [applied, setApplied] = useState<AppliedState>({ kind: "idle" });
+  const [testCode, setTestCode] = useState("XK");
+  const [testInput, setTestInput] = useState("10000");
+  const [guessInput, setGuessInput] = useState("10000");
+  const [shareState, setShareState] = useState<"idle" | "copied">("idle");
+  const shareTimer = useRef<number | null>(null);
+
+  // Reset any leftover config from prior sessions when the tab mounts.
+  useEffect(() => {
+    resetConfig();
+    return () => {
+      resetConfig();
+    };
+  }, []);
+
+  const handleApply = useCallback(() => {
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(text);
+    } catch (err) {
+      setError(err instanceof Error ? `JSON parse error: ${err.message}` : "Invalid JSON");
+      setApplied({ kind: "idle" });
+      return;
+    }
+
+    try {
+      configure(parsed as PostalCodeConfig);
+    } catch (err) {
+      if (err instanceof ConfigurationError) {
+        setError(err.message);
+      } else {
+        setError(err instanceof Error ? err.message : String(err));
+      }
+      setApplied({ kind: "idle" });
+      return;
+    }
+
+    setError(null);
+    setApplied({
+      kind: "applied",
+      diff: computeDiff(parsed as PostalCodeConfig),
+      at: Date.now(),
+    });
+  }, [text]);
+
+  const handleReset = useCallback(() => {
+    resetConfig();
+    setError(null);
+    setApplied({ kind: "reset", at: Date.now() });
+  }, []);
+
+  const handleShare = useCallback(async () => {
+    const base = `${window.location.origin}${window.location.pathname}${window.location.search}`;
+    const hash = encodeConfigToHash(text);
+    const url = `${base}${hash}`;
+    history.replaceState(null, "", url);
+    try {
+      await navigator.clipboard.writeText(url);
+    } catch {
+      // Ignore — URL is still in the address bar.
+    }
+    setShareState("copied");
+    if (shareTimer.current) window.clearTimeout(shareTimer.current);
+    shareTimer.current = window.setTimeout(() => setShareState("idle"), 1400);
+  }, [text]);
+
+  useEffect(() => {
+    return () => {
+      if (shareTimer.current) window.clearTimeout(shareTimer.current);
+    };
+  }, []);
+
+  // Reactive values — re-read the live dataset whenever `applied` changes so
+  // the right-pane cards reflect what `configure()` / `resetConfig()` just did.
+  const validatorResult = useMemo(() => {
+    const country = getCountryByCode(testCode);
+    if (!country) return { ok: false, reason: "country-unknown" as const };
+    const ok = validatePostalCode(testCode, testInput);
+    return { ok, reason: ok ? "match" : ("no-match" as const), country };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [testCode, testInput, applied]);
+
+  const guessMatches = useMemo(
+    () => guessCountries(guessInput),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [guessInput, applied],
+  );
+
+  const diff = applied.kind === "applied" ? applied.diff : [];
+
+  return (
+    <div className={styles.panel}>
+      <div className={styles.header}>
+        <div>
+          <h3>configure() — custom country data</h3>
+          <p>
+            Drop in a JSON config and every utility in the package picks it up — one call at app
+            boot, no per-call wiring. Same idea as an <code>i18next.init()</code> but for postal
+            codes.
+          </p>
+        </div>
+        <div className={styles.actions}>
+          <button
+            type="button"
+            className={`${styles.button} ${styles.apply}`}
+            onClick={handleApply}
+          >
+            Apply config
+          </button>
+          <button type="button" className={styles.button} onClick={handleReset}>
+            resetConfig()
+          </button>
+          <button type="button" className={styles.button} onClick={handleShare}>
+            {shareState === "copied" ? "Link copied" : "Share"}
+          </button>
+        </div>
+      </div>
+
+      <div className={styles.grid}>
+        <div className={styles.editorWrap}>
+          <div className={styles.paneLabel}>
+            <span>custom-countries.json</span>
+            <span>{text.split("\n").length} lines</span>
+          </div>
+          <textarea
+            className={styles.textarea}
+            value={text}
+            onChange={(e) => setText(e.target.value)}
+            spellCheck={false}
+            data-state={error ? "error" : undefined}
+            aria-label="Postal code configuration JSON"
+          />
+          {error ? (
+            <div className={styles.errorBanner} role="alert">
+              {error}
+            </div>
+          ) : applied.kind === "applied" ? (
+            <div className={styles.appliedBanner}>
+              Config applied — {diff.length} {diff.length === 1 ? "country" : "countries"} in effect.
+            </div>
+          ) : applied.kind === "reset" ? (
+            <div className={styles.appliedBanner}>
+              Reset to bundled defaults. Nothing is overridden.
+            </div>
+          ) : null}
+        </div>
+
+        <div className={styles.right}>
+          <div className={styles.card}>
+            <h4 className={styles.cardTitle}>Diff vs bundled dataset</h4>
+            {applied.kind === "applied" && diff.length > 0 ? (
+              diff.map((d) => (
+                <div key={d.code} className={styles.diffRow}>
+                  <span className={`${styles.tag} ${styles[d.kind]}`}>{d.kind}</span>
+                  <strong>{d.code}</strong>
+                  <span>{d.country}</span>
+                </div>
+              ))
+            ) : (
+              <p className={styles.diffNone}>
+                {applied.kind === "reset"
+                  ? "No overrides. The 249 bundled countries are active."
+                  : "Click Apply config to see what changed."}
+              </p>
+            )}
+          </div>
+
+          <div className={styles.card}>
+            <h4 className={styles.cardTitle}>validatePostalCode()</h4>
+            <div className={styles.validatorRow}>
+              <span className={styles.validatorLabel}>Country</span>
+              <input
+                className={styles.input}
+                value={testCode}
+                onChange={(e) => setTestCode(e.target.value.toUpperCase())}
+                maxLength={3}
+                spellCheck={false}
+                aria-label="Country code to test"
+              />
+              <span
+                className={`${styles.status} ${
+                  validatorResult.reason === "country-unknown" ? styles.bad : styles.bundled
+                }`}
+              >
+                {validatorResult.reason === "country-unknown"
+                  ? "unknown"
+                  : validatorResult.country?.countryName.slice(0, 18)}
+              </span>
+            </div>
+            <div className={styles.validatorRow} style={{ marginTop: 6 }}>
+              <span className={styles.validatorLabel}>Postal</span>
+              <input
+                className={styles.input}
+                value={testInput}
+                onChange={(e) => setTestInput(e.target.value)}
+                spellCheck={false}
+                aria-label="Postal code to validate"
+              />
+              <span
+                className={`${styles.status} ${validatorResult.ok ? styles.ok : styles.bad}`}
+              >
+                {validatorResult.ok ? "valid" : "invalid"}
+              </span>
+            </div>
+          </div>
+
+          <div className={styles.card}>
+            <h4 className={styles.cardTitle}>guessCountries()</h4>
+            <div className={styles.validatorRow} style={{ gridTemplateColumns: "88px 1fr" }}>
+              <span className={styles.validatorLabel}>Postal</span>
+              <input
+                className={styles.input}
+                value={guessInput}
+                onChange={(e) => setGuessInput(e.target.value)}
+                spellCheck={false}
+                aria-label="Postal code to guess countries for"
+              />
+            </div>
+            <div className={styles.guessList} style={{ marginTop: 10 }}>
+              {guessMatches.length === 0 ? (
+                <span className={styles.chip}>No country accepts this input</span>
+              ) : (
+                guessMatches.slice(0, 24).map((m) => (
+                  <span key={m.countryCode} className={styles.chip}>
+                    <strong>{m.countryCode}</strong> · {m.countryName}
+                  </span>
+                ))
+              )}
+              {guessMatches.length > 24 && (
+                <span className={styles.chip}>+{guessMatches.length - 24} more</span>
+              )}
+            </div>
+          </div>
+
+          <p className={styles.note}>
+            <strong>When to call <code>resetConfig()</code>?</strong> In tests (so configs don't
+            leak between specs), in dev tools that switch datasets at runtime, and after a hot
+            module reload so stale overrides don't pile up.
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/demo/src/components/ConfigurationPanel.tsx
+++ b/demo/src/components/ConfigurationPanel.tsx
@@ -154,28 +154,27 @@ export function ConfigurationPanel() {
       <div className={styles.shareCorner}>
         <ShareButton paramName="config" getValue={getShareValue} ariaLabel="Share this config" />
       </div>
-      <div className={styles.header}>
-        <div>
+      <div className={styles.intro}>
+        <div className={styles.introCopy}>
           <h3>configure() — custom country data</h3>
           <p>
-            Drop in a JSON config and every utility in the package picks it up — one call at app
-            boot, no per-call wiring. The config lives in a module-level singleton, so the same
-            three-line setup works in React, Vue, Angular, Svelte, Node, Bun, Deno, and plain
-            browser JS.
+            Drop in a JSON config and every utility in the package picks it up —
+            one call at app boot, no per-call wiring. The config lives in a
+            module-level singleton, so the same three-line setup works in
+            React, Vue, Angular, Svelte, Node, Bun, Deno, and plain browser JS.
           </p>
         </div>
-      </div>
-
-      <div className={styles.wiringBlock}>
-        <div className={styles.wiringIntro}>
-          <strong>How it wires into your app</strong>
-          <span>
-            Three steps, one file. The JSON on the left is shorthand for this —
-            call configure() once and every utility in the package reads the
-            merged dataset.
-          </span>
+        <div className={styles.wiringBlock}>
+          <div className={styles.wiringIntro}>
+            <strong>How it wires into your app</strong>
+            <span>
+              Three steps, one file. The JSON on the left is shorthand for
+              this — call <code>configure()</code> once and every utility reads
+              the merged dataset.
+            </span>
+          </div>
+          <CodeBlock code={WIRING_EXAMPLE} ariaLabel="configure() wiring example" />
         </div>
-        <CodeBlock code={WIRING_EXAMPLE} ariaLabel="configure() wiring example" />
       </div>
 
       <ol className={styles.steps} aria-label="How to try a custom configuration">

--- a/demo/src/components/ConfigurationPanel.tsx
+++ b/demo/src/components/ConfigurationPanel.tsx
@@ -10,7 +10,7 @@ import {
   type PostalCodeConfig,
 } from "postal-code-checker";
 import { readShareParam } from "../data/share";
-import { ExamplePlayground } from "./ExamplePlayground";
+import { CodeBlock } from "./ui/CodeBlock";
 import { ShareButton } from "./ui/ShareButton";
 import styles from "./ConfigurationPanel.module.scss";
 
@@ -31,29 +31,24 @@ const DEFAULT_CONFIG_JSON = `{
 }
 `;
 
-const WIRING_EXAMPLE = `// 1. In your app you'd import the JSON (or inline an object):
-//      import customCountries from "./custom-countries.json";
-//      import { configure } from "postal-code-checker";
-//    Here the dependencies are already in scope — edit freely, hit Run.
+const WIRING_EXAMPLE = `// 1. Load your config — usually a JSON file imported at app boot.
+import customCountries from "./custom-countries.json";
+import { configure } from "postal-code-checker";
 
-// 2. At app boot — call once. The config is a module-level singleton
-//    so every downstream import reads the merged dataset.
-configure({
-  countries: {
-    XK: {
-      patterns: ["/^(?:[1-7]\\\\d{4})$/"],
-      example: ["10000", "20000"],
-      country: "Kosovo",
-      alpha3: "XKX",
-    },
-  },
-});
+// 2. Call once. configure() is a module-level singleton, so every
+//    downstream import reads the merged dataset without extra wiring.
+configure(customCountries);
 
-// 3. Validate + guess run against the new dataset.
-console.log("XK validates 10000:", validatePostalCode("XK", "10000"));
+// 3. Everything else just works — validate, format, guess, lookups
+//    all read the new patterns with no per-call threading.
+import {
+  validatePostalCode,
+  guessCountries,
+} from "postal-code-checker";
 
-const matches = guessCountries("10000").map(c => c.countryCode);
-console.log("guessCountries('10000'):", matches.slice(0, 8).join(", "));
+validatePostalCode("XK", "10000");         // true
+guessCountries("10000").map(c => c.countryCode);
+// → ["FR", "IT", "XK", …]
 `;
 
 type DiffEntry = {
@@ -172,12 +167,15 @@ export function ConfigurationPanel() {
       </div>
 
       <div className={styles.wiringBlock}>
-        <ExamplePlayground
-          shareKey="ex-configure"
-          title="How it wires into your app"
-          description="Runnable — edit the config, hit Run, watch configure() + validate + guess update in place."
-          initialCode={WIRING_EXAMPLE}
-        />
+        <div className={styles.wiringIntro}>
+          <strong>How it wires into your app</strong>
+          <span>
+            Three steps, one file. The JSON on the left is shorthand for this —
+            call configure() once and every utility in the package reads the
+            merged dataset.
+          </span>
+        </div>
+        <CodeBlock code={WIRING_EXAMPLE} ariaLabel="configure() wiring example" />
       </div>
 
       <ol className={styles.steps} aria-label="How to try a custom configuration">

--- a/demo/src/components/ConfigurationPanel.tsx
+++ b/demo/src/components/ConfigurationPanel.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import {
   COUNTRIES,
   ConfigurationError,
@@ -9,6 +9,9 @@ import {
   validatePostalCode,
   type PostalCodeConfig,
 } from "postal-code-checker";
+import { readShareParam } from "../data/share";
+import { CodeBlock } from "./ui/CodeBlock";
+import { ShareButton } from "./ui/ShareButton";
 import styles from "./ConfigurationPanel.module.scss";
 
 const DEFAULT_CONFIG_JSON = `{
@@ -28,6 +31,20 @@ const DEFAULT_CONFIG_JSON = `{
 }
 `;
 
+const WIRING_EXAMPLE = `// 1. Put your overrides in a JSON file (or inline object).
+import customCountries from "./custom-countries.json";
+
+// 2. At app boot — call once; the config is a module-level singleton
+//    so every downstream import picks it up without extra wiring.
+import { configure } from "postal-code-checker";
+configure(customCountries);
+
+// 3. Every utility in the package now reads the merged dataset.
+import { validatePostalCode, guessCountries } from "postal-code-checker";
+validatePostalCode("XK", "10000");   // → true
+guessCountries("10000").length;      // now includes Kosovo
+`;
+
 type DiffEntry = {
   code: string;
   kind: "added" | "replaced";
@@ -38,25 +55,6 @@ type AppliedState =
   | { kind: "idle" }
   | { kind: "applied"; diff: DiffEntry[]; at: number }
   | { kind: "reset"; at: number };
-
-function encodeConfigToHash(text: string): string {
-  try {
-    return "#config=" + btoa(unescape(encodeURIComponent(text)));
-  } catch {
-    return "";
-  }
-}
-
-function decodeConfigFromHash(): string | null {
-  const hash = window.location.hash;
-  if (!hash.startsWith("#config=")) return null;
-  try {
-    const raw = hash.slice("#config=".length);
-    return decodeURIComponent(escape(atob(raw)));
-  } catch {
-    return null;
-  }
-}
 
 function computeDiff(config: PostalCodeConfig): DiffEntry[] {
   const entries: DiffEntry[] = [];
@@ -73,15 +71,13 @@ function computeDiff(config: PostalCodeConfig): DiffEntry[] {
 
 export function ConfigurationPanel() {
   const [text, setText] = useState<string>(
-    () => decodeConfigFromHash() ?? DEFAULT_CONFIG_JSON,
+    () => readShareParam("config") ?? DEFAULT_CONFIG_JSON,
   );
   const [error, setError] = useState<string | null>(null);
   const [applied, setApplied] = useState<AppliedState>({ kind: "idle" });
   const [testCode, setTestCode] = useState("XK");
   const [testInput, setTestInput] = useState("10000");
   const [guessInput, setGuessInput] = useState("10000");
-  const [shareState, setShareState] = useState<"idle" | "copied">("idle");
-  const shareTimer = useRef<number | null>(null);
 
   // Reset any leftover config from prior sessions when the tab mounts.
   useEffect(() => {
@@ -127,28 +123,9 @@ export function ConfigurationPanel() {
     setApplied({ kind: "reset", at: Date.now() });
   }, []);
 
-  const handleShare = useCallback(async () => {
-    const base = `${window.location.origin}${window.location.pathname}${window.location.search}`;
-    const hash = encodeConfigToHash(text);
-    const url = `${base}${hash}`;
-    history.replaceState(null, "", url);
-    try {
-      await navigator.clipboard.writeText(url);
-    } catch {
-      // Ignore — URL is still in the address bar.
-    }
-    setShareState("copied");
-    if (shareTimer.current) window.clearTimeout(shareTimer.current);
-    shareTimer.current = window.setTimeout(() => setShareState("idle"), 1400);
-  }, [text]);
+  const getShareValue = useCallback(() => text, [text]);
 
-  useEffect(() => {
-    return () => {
-      if (shareTimer.current) window.clearTimeout(shareTimer.current);
-    };
-  }, []);
-
-  // Reactive values — re-read the live dataset whenever `applied` changes so
+  // Reactive values re-read the live dataset whenever `applied` changes, so
   // the right-pane cards reflect what `configure()` / `resetConfig()` just did.
   const validatorResult = useMemo(() => {
     const country = getCountryByCode(testCode);
@@ -168,31 +145,62 @@ export function ConfigurationPanel() {
 
   return (
     <div className={styles.panel}>
+      <div className={styles.shareCorner}>
+        <ShareButton paramName="config" getValue={getShareValue} ariaLabel="Share this config" />
+      </div>
       <div className={styles.header}>
         <div>
           <h3>configure() — custom country data</h3>
           <p>
             Drop in a JSON config and every utility in the package picks it up — one call at app
-            boot, no per-call wiring. Same idea as an <code>i18next.init()</code> but for postal
-            codes.
+            boot, no per-call wiring. The config lives in a module-level singleton, so the same
+            three-line setup works in React, Vue, Angular, Svelte, Node, Bun, Deno, and plain
+            browser JS.
           </p>
         </div>
-        <div className={styles.actions}>
-          <button
-            type="button"
-            className={`${styles.button} ${styles.apply}`}
-            onClick={handleApply}
-          >
-            Apply config
-          </button>
-          <button type="button" className={styles.button} onClick={handleReset}>
-            resetConfig()
-          </button>
-          <button type="button" className={styles.button} onClick={handleShare}>
-            {shareState === "copied" ? "Link copied" : "Share"}
-          </button>
-        </div>
       </div>
+
+      <div className={styles.wiringBlock}>
+        <div className={styles.wiringIntro}>
+          <strong>How it wires into your app</strong>
+          <span>
+            Three lines at startup — the JSON document you edit below is exactly the shape you
+            pass to <code>configure()</code>.
+          </span>
+        </div>
+        <CodeBlock code={WIRING_EXAMPLE} ariaLabel="configure() wiring example" />
+      </div>
+
+      <ol className={styles.steps} aria-label="How to try a custom configuration">
+        <li>
+          <span className={styles.stepNum}>1</span>
+          <div>
+            <strong>Edit the JSON</strong> on the left. Add a new country code, or replace an
+            existing one's patterns.
+          </div>
+        </li>
+        <li>
+          <span className={styles.stepNum}>2</span>
+          <div>
+            Click <strong>Apply config</strong>. The panel calls <code>configure()</code> for real;
+            invalid configs throw <code>ConfigurationError</code> and show inline.
+          </div>
+        </li>
+        <li>
+          <span className={styles.stepNum}>3</span>
+          <div>
+            Test it on the right — <strong>validatePostalCode()</strong> and{" "}
+            <strong>guessCountries()</strong> read from the live dataset.
+          </div>
+        </li>
+        <li>
+          <span className={styles.stepNum}>4</span>
+          <div>
+            Click <strong>Share</strong> to copy a URL with this config baked in, or{" "}
+            <strong>resetConfig()</strong> to revert to the 249 bundled countries.
+          </div>
+        </li>
+      </ol>
 
       <div className={styles.grid}>
         <div className={styles.editorWrap}>
@@ -208,6 +216,18 @@ export function ConfigurationPanel() {
             data-state={error ? "error" : undefined}
             aria-label="Postal code configuration JSON"
           />
+          <div className={styles.editorActions}>
+            <button
+              type="button"
+              className={`${styles.button} ${styles.apply}`}
+              onClick={handleApply}
+            >
+              Apply config
+            </button>
+            <button type="button" className={styles.button} onClick={handleReset}>
+              resetConfig()
+            </button>
+          </div>
           {error ? (
             <div className={styles.errorBanner} role="alert">
               {error}

--- a/demo/src/components/ConfigurationPanel.tsx
+++ b/demo/src/components/ConfigurationPanel.tsx
@@ -10,7 +10,7 @@ import {
   type PostalCodeConfig,
 } from "postal-code-checker";
 import { readShareParam } from "../data/share";
-import { CodeBlock } from "./ui/CodeBlock";
+import { ExamplePlayground } from "./ExamplePlayground";
 import { ShareButton } from "./ui/ShareButton";
 import styles from "./ConfigurationPanel.module.scss";
 
@@ -31,18 +31,29 @@ const DEFAULT_CONFIG_JSON = `{
 }
 `;
 
-const WIRING_EXAMPLE = `// 1. Put your overrides in a JSON file (or inline object).
-import customCountries from "./custom-countries.json";
+const WIRING_EXAMPLE = `// 1. In your app you'd import the JSON (or inline an object):
+//      import customCountries from "./custom-countries.json";
+//      import { configure } from "postal-code-checker";
+//    Here the dependencies are already in scope — edit freely, hit Run.
 
-// 2. At app boot — call once; the config is a module-level singleton
-//    so every downstream import picks it up without extra wiring.
-import { configure } from "postal-code-checker";
-configure(customCountries);
+// 2. At app boot — call once. The config is a module-level singleton
+//    so every downstream import reads the merged dataset.
+configure({
+  countries: {
+    XK: {
+      patterns: ["/^(?:[1-7]\\\\d{4})$/"],
+      example: ["10000", "20000"],
+      country: "Kosovo",
+      alpha3: "XKX",
+    },
+  },
+});
 
-// 3. Every utility in the package now reads the merged dataset.
-import { validatePostalCode, guessCountries } from "postal-code-checker";
-validatePostalCode("XK", "10000");   // → true
-guessCountries("10000").length;      // now includes Kosovo
+// 3. Validate + guess run against the new dataset.
+console.log("XK validates 10000:", validatePostalCode("XK", "10000"));
+
+const matches = guessCountries("10000").map(c => c.countryCode);
+console.log("guessCountries('10000'):", matches.slice(0, 8).join(", "));
 `;
 
 type DiffEntry = {
@@ -161,14 +172,12 @@ export function ConfigurationPanel() {
       </div>
 
       <div className={styles.wiringBlock}>
-        <div className={styles.wiringIntro}>
-          <strong>How it wires into your app</strong>
-          <span>
-            Three lines at startup — the JSON document you edit below is exactly the shape you
-            pass to <code>configure()</code>.
-          </span>
-        </div>
-        <CodeBlock code={WIRING_EXAMPLE} ariaLabel="configure() wiring example" />
+        <ExamplePlayground
+          shareKey="ex-configure"
+          title="How it wires into your app"
+          description="Runnable — edit the config, hit Run, watch configure() + validate + guess update in place."
+          initialCode={WIRING_EXAMPLE}
+        />
       </div>
 
       <ol className={styles.steps} aria-label="How to try a custom configuration">

--- a/demo/src/components/ConfigurationPanel.tsx
+++ b/demo/src/components/ConfigurationPanel.tsx
@@ -154,8 +154,8 @@ export function ConfigurationPanel() {
       <div className={styles.shareCorner}>
         <ShareButton paramName="config" getValue={getShareValue} ariaLabel="Share this config" />
       </div>
-      <div className={styles.intro}>
-        <div className={styles.introCopy}>
+      <div className={styles.header}>
+        <div>
           <h3>configure() — custom country data</h3>
           <p>
             Drop in a JSON config and every utility in the package picks it up —
@@ -164,17 +164,18 @@ export function ConfigurationPanel() {
             React, Vue, Angular, Svelte, Node, Bun, Deno, and plain browser JS.
           </p>
         </div>
-        <div className={styles.wiringBlock}>
-          <div className={styles.wiringIntro}>
-            <strong>How it wires into your app</strong>
-            <span>
-              Three steps, one file. The JSON on the left is shorthand for
-              this — call <code>configure()</code> once and every utility reads
-              the merged dataset.
-            </span>
-          </div>
-          <CodeBlock code={WIRING_EXAMPLE} ariaLabel="configure() wiring example" />
+      </div>
+
+      <div className={styles.wiringBlock}>
+        <div className={styles.wiringIntro}>
+          <strong>How it wires into your app</strong>
+          <span>
+            Three steps, one file. The JSON on the left is shorthand for this —
+            call <code>configure()</code> once and every utility reads the
+            merged dataset.
+          </span>
         </div>
+        <CodeBlock code={WIRING_EXAMPLE} ariaLabel="configure() wiring example" />
       </div>
 
       <ol className={styles.steps} aria-label="How to try a custom configuration">

--- a/demo/src/components/CustomCountryCta.module.scss
+++ b/demo/src/components/CustomCountryCta.module.scss
@@ -1,0 +1,129 @@
+@use "../styles/variables" as *;
+@use "../styles/mixins" as *;
+
+.banner {
+  margin-top: 32px;
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  align-items: center;
+  gap: 18px;
+  padding: 18px 22px;
+  background:
+    linear-gradient(135deg, var(--color-accent-soft), transparent 70%),
+    var(--color-panel);
+  border: 1px solid var(--color-accent-soft);
+  border-radius: $radius-lg;
+  box-shadow: var(--shadow-sm);
+
+  @include below-lg {
+    grid-template-columns: 1fr;
+    gap: 12px;
+    padding: 18px 18px 20px;
+  }
+}
+
+.iconWrap {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 40px;
+  height: 40px;
+  border-radius: 999px;
+  background: var(--color-accent-soft);
+  color: var(--color-accent);
+
+  svg {
+    width: 22px;
+    height: 22px;
+  }
+
+  @include below-lg {
+    grid-row: 1;
+  }
+}
+
+.copy {
+  min-width: 0;
+
+  h3 {
+    margin: 0 0 2px;
+    font-size: 15.5px;
+    font-weight: 600;
+    letter-spacing: -0.01em;
+    color: var(--color-text);
+
+    em {
+      font-style: normal;
+      color: var(--color-accent);
+    }
+  }
+
+  p {
+    margin: 0;
+    font-size: 13.5px;
+    line-height: 1.55;
+    color: var(--color-muted);
+  }
+
+  code {
+    font-family: $font-mono;
+    font-size: 12px;
+    padding: 1px 5px;
+    border-radius: 4px;
+    background: var(--color-panel-2);
+    border: 1px solid var(--color-border);
+    color: var(--color-text);
+  }
+}
+
+.badge {
+  display: inline-flex;
+  align-items: center;
+  padding: 1px 7px;
+  margin-left: 4px;
+  font-family: $font-mono;
+  font-size: 10.5px;
+  font-weight: 700;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: #fff;
+  background: var(--color-accent);
+  border-radius: 999px;
+  vertical-align: 1px;
+}
+
+.cta {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-family: $font-sans;
+  font-size: 13px;
+  font-weight: 600;
+  padding: 9px 14px;
+  border-radius: $radius;
+  background: var(--color-accent);
+  color: #fff;
+  border: 1px solid var(--color-accent);
+  text-decoration: none;
+  transition: filter $duration-fast $ease, transform $duration-fast $ease;
+  white-space: nowrap;
+
+  svg {
+    width: 14px;
+    height: 14px;
+  }
+
+  &:hover {
+    filter: brightness(1.05);
+    transform: translateX(2px);
+  }
+
+  &:focus-visible {
+    outline: none;
+    box-shadow: 0 0 0 3px var(--color-accent-soft);
+  }
+
+  @include below-lg {
+    justify-self: start;
+  }
+}

--- a/demo/src/components/CustomCountryCta.tsx
+++ b/demo/src/components/CustomCountryCta.tsx
@@ -32,13 +32,15 @@ export function CustomCountryCta() {
       </div>
       <div className={styles.copy}>
         <h3 id="custom-country-cta-heading">
-          Don't see your country? <em>Add your own.</em>
+          Don't see your country? <em>Add your own.</em> Or tighten an existing
+          one.
         </h3>
         <p>
-          Ship internal codes, Kosovo, a dev sandbox — anything the bundled
-          249 don't cover. One <code>configure()</code> call at app boot and
-          every utility reads the merged dataset.{" "}
-          <span className={styles.badge}>new in 2.1</span>
+          Add brand-new entries (internal codes, Kosovo, a dev sandbox) or
+          replace a bundled pattern when your business rules are stricter than
+          the defaults. One <code>configure()</code> call at app boot and every
+          utility reads the merged dataset.{" "}
+          <span className={styles.badge}>new in 2.1.0</span>
         </p>
       </div>
       <a

--- a/demo/src/components/CustomCountryCta.tsx
+++ b/demo/src/components/CustomCountryCta.tsx
@@ -32,14 +32,16 @@ export function CustomCountryCta() {
       </div>
       <div className={styles.copy}>
         <h3 id="custom-country-cta-heading">
-          Don't see your country? <em>Add your own.</em> Or tighten an existing
-          one.
+          Missing a country? <em>Add your own.</em> Rules changed?{" "}
+          <em>Patch it in place.</em>
         </h3>
         <p>
-          Add brand-new entries (internal codes, Kosovo, a dev sandbox) or
-          replace a bundled pattern when your business rules are stricter than
-          the defaults. One <code>configure()</code> call at app boot and every
-          utility reads the merged dataset.{" "}
+          Add brand-new entries (internal codes, Kosovo, a dev sandbox), tighten
+          a bundled pattern when your business rules are stricter than the
+          defaults, or drop in an updated regex the moment a postal authority
+          changes its format — no need to wait for the next{" "}
+          <code>postal-code-checker</code> release. One <code>configure()</code>{" "}
+          call at app boot and every utility reads the merged dataset.{" "}
           <span className={styles.badge}>new in 2.1.0</span>
         </p>
       </div>

--- a/demo/src/components/CustomCountryCta.tsx
+++ b/demo/src/components/CustomCountryCta.tsx
@@ -1,0 +1,65 @@
+import { useCallback } from "react";
+import styles from "./CustomCountryCta.module.scss";
+
+export function CustomCountryCta() {
+  const handleJump = useCallback((e: React.MouseEvent<HTMLAnchorElement>) => {
+    e.preventDefault();
+    const target = document.getElementById("configuration");
+    if (target) {
+      target.scrollIntoView({ behavior: "smooth", block: "start" });
+      history.replaceState(null, "", "#configuration");
+    }
+  }, []);
+
+  return (
+    <aside
+      className={styles.banner}
+      aria-labelledby="custom-country-cta-heading"
+    >
+      <div className={styles.iconWrap} aria-hidden="true">
+        <svg
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        >
+          <circle cx="12" cy="12" r="10" />
+          <line x1="2" y1="12" x2="22" y2="12" />
+          <path d="M12 2a15.3 15.3 0 0 1 4 10 15.3 15.3 0 0 1-4 10 15.3 15.3 0 0 1-4-10 15.3 15.3 0 0 1 4-10z" />
+        </svg>
+      </div>
+      <div className={styles.copy}>
+        <h3 id="custom-country-cta-heading">
+          Don't see your country? <em>Add your own.</em>
+        </h3>
+        <p>
+          Ship internal codes, Kosovo, a dev sandbox — anything the bundled
+          249 don't cover. One <code>configure()</code> call at app boot and
+          every utility reads the merged dataset.{" "}
+          <span className={styles.badge}>new in 2.1</span>
+        </p>
+      </div>
+      <a
+        href="#configuration"
+        className={styles.cta}
+        onClick={handleJump}
+      >
+        Try it live
+        <svg
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2.25"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          aria-hidden="true"
+        >
+          <line x1="5" y1="12" x2="19" y2="12" />
+          <polyline points="12 5 19 12 12 19" />
+        </svg>
+      </a>
+    </aside>
+  );
+}

--- a/demo/src/components/DatasetPanel.module.scss
+++ b/demo/src/components/DatasetPanel.module.scss
@@ -10,6 +10,14 @@
   display: flex;
   flex-direction: column;
   height: 520px;
+  position: relative;
+}
+
+.shareCorner {
+  position: absolute;
+  top: 14px;
+  right: 14px;
+  z-index: 1;
 }
 
 .header {

--- a/demo/src/components/DatasetPanel.tsx
+++ b/demo/src/components/DatasetPanel.tsx
@@ -1,9 +1,11 @@
-import { useMemo, useState, type RefObject } from "react";
+import { useCallback, useEffect, useMemo, useState, type RefObject } from "react";
 import {
   getAllCountries,
   getCountryByCode,
   type Country,
 } from "postal-code-checker";
+import { readShareParam } from "../data/share";
+import { ShareButton } from "./ui/ShareButton";
 import styles from "./DatasetPanel.module.scss";
 
 type Props = {
@@ -33,13 +35,45 @@ function buildRows(): Row[] {
     .sort((a, b) => a.name.localeCompare(b.name));
 }
 
+type Shared = { query: string; country?: string };
+
+function loadInitial(): Shared {
+  const raw = readShareParam("dataset");
+  if (raw) {
+    try {
+      const parsed = JSON.parse(raw) as Partial<Shared>;
+      return {
+        query: typeof parsed.query === "string" ? parsed.query : "",
+        country: typeof parsed.country === "string" ? parsed.country : undefined,
+      };
+    } catch {
+      // fall through to defaults
+    }
+  }
+  return { query: "" };
+}
+
 export function DatasetPanel({
   activeCountry,
   onPickCountry,
   searchRef,
 }: Props) {
   const rows = useMemo(buildRows, []);
-  const [query, setQuery] = useState("");
+  const initial = useMemo(loadInitial, []);
+  const [query, setQuery] = useState(initial.query);
+
+  useEffect(() => {
+    if (initial.country && initial.country !== activeCountry) {
+      onPickCountry?.(initial.country);
+    }
+    // Only run once on mount — activeCountry changes shouldn't re-trigger.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const getShareValue = useCallback(
+    () => JSON.stringify({ query, country: activeCountry ?? "" }),
+    [query, activeCountry],
+  );
 
   const filtered = useMemo(() => {
     const q = query.trim().toLowerCase();
@@ -54,6 +88,13 @@ export function DatasetPanel({
 
   return (
     <div className={styles.panel}>
+      <div className={styles.shareCorner}>
+        <ShareButton
+          paramName="dataset"
+          getValue={getShareValue}
+          ariaLabel="Share this dataset view"
+        />
+      </div>
       <div className={styles.header}>
         <div>
           <h3>Dataset browser</h3>

--- a/demo/src/components/ExamplePlayground.module.scss
+++ b/demo/src/components/ExamplePlayground.module.scss
@@ -7,6 +7,20 @@
   border-radius: $radius-lg;
   padding: 22px;
   box-shadow: var(--shadow-sm);
+  position: relative;
+}
+
+.shareCorner {
+  position: absolute;
+  top: 14px;
+  right: 14px;
+  z-index: 1;
+}
+
+.outputActions {
+  display: flex;
+  align-items: center;
+  gap: 8px;
 }
 
 .header {
@@ -32,17 +46,28 @@
 }
 
 .reset {
-  padding: 6px 12px;
-  font-size: 12px;
+  padding: 2px 10px;
+  font-family: $font-sans;
+  font-size: 11px;
   font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
   color: var(--color-muted);
+  background: transparent;
   border: 1px solid var(--color-border);
   border-radius: $radius-sm;
+  cursor: pointer;
   transition: color $duration-fast $ease, border-color $duration-fast $ease;
 
   &:hover {
     color: var(--color-text);
     border-color: var(--color-accent);
+  }
+
+  &:focus-visible {
+    outline: none;
+    border-color: var(--color-accent);
+    box-shadow: 0 0 0 3px var(--color-accent-soft);
   }
 }
 

--- a/demo/src/components/ExamplePlayground.module.scss
+++ b/demo/src/components/ExamplePlayground.module.scss
@@ -10,13 +10,6 @@
   position: relative;
 }
 
-.shareCorner {
-  position: absolute;
-  top: 14px;
-  right: 14px;
-  z-index: 1;
-}
-
 .outputActions {
   display: flex;
   align-items: center;

--- a/demo/src/components/ExamplePlayground.tsx
+++ b/demo/src/components/ExamplePlayground.tsx
@@ -3,11 +3,18 @@ import CodeMirror from "@uiw/react-codemirror";
 import { javascript } from "@codemirror/lang-javascript";
 import { darcula } from "@uiw/codemirror-theme-darcula";
 import {
+  ConfigurationError,
+  configure,
+  format,
+  getAllCountries,
+  getCountryByCode,
+  guessCountries,
+  resetConfig,
   validatePostalCode,
   validatePostalCodes,
-  getCountryByCode,
-  getAllCountries,
 } from "postal-code-checker";
+import { readShareParam } from "../data/share";
+import { ShareButton } from "./ui/ShareButton";
 import styles from "./ExamplePlayground.module.scss";
 
 type RunResult = { output: string; isError: boolean };
@@ -36,16 +43,32 @@ function runSnippet(code: string): RunResult {
       "validatePostalCodes",
       "getCountryByCode",
       "getAllCountries",
+      "guessCountries",
+      "format",
+      "configure",
+      "resetConfig",
+      "ConfigurationError",
       "console",
       `"use strict";\n${code}`,
     );
-    fn(
-      validatePostalCode,
-      validatePostalCodes,
-      getCountryByCode,
-      getAllCountries,
-      fakeConsole,
-    );
+    try {
+      fn(
+        validatePostalCode,
+        validatePostalCodes,
+        getCountryByCode,
+        getAllCountries,
+        guessCountries,
+        format,
+        configure,
+        resetConfig,
+        ConfigurationError,
+        fakeConsole,
+      );
+    } finally {
+      // Snippets may call configure() — drop overrides so they don't leak
+      // into the rest of the playground (dataset, batch, format panels).
+      resetConfig();
+    }
     return {
       output: logs.join("\n") || "// no output — use console.log(...) to print",
       isError: false,
@@ -60,14 +83,19 @@ function runSnippet(code: string): RunResult {
 }
 
 type Props = {
+  shareKey: string;
   title: string;
   description?: string;
   initialCode: string;
 };
 
-export function ExamplePlayground({ title, description, initialCode }: Props) {
-  const [code, setCode] = useState(initialCode);
-  const [result, setResult] = useState<RunResult>(() => runSnippet(initialCode));
+export function ExamplePlayground({ shareKey, title, description, initialCode }: Props) {
+  const startingCode = useMemo(
+    () => readShareParam(shareKey) ?? initialCode,
+    [shareKey, initialCode],
+  );
+  const [code, setCode] = useState(startingCode);
+  const [result, setResult] = useState<RunResult>(() => runSnippet(startingCode));
   const [pending, setPending] = useState(false);
   const firstRun = useRef(true);
 
@@ -89,19 +117,18 @@ export function ExamplePlayground({ title, description, initialCode }: Props) {
 
   return (
     <div className={styles.panel}>
+      <div className={styles.shareCorner}>
+        <ShareButton
+          paramName={shareKey}
+          getValue={() => code}
+          ariaLabel={`Share ${title}`}
+        />
+      </div>
       <div className={styles.header}>
         <div>
           <h3>{title}</h3>
           {description && <p>{description}</p>}
         </div>
-        <button
-          type="button"
-          className={styles.reset}
-          onClick={() => setCode(initialCode)}
-          aria-label={`Reset ${title} snippet`}
-        >
-          Reset
-        </button>
       </div>
 
       <div className={styles.grid}>
@@ -134,9 +161,19 @@ export function ExamplePlayground({ title, description, initialCode }: Props) {
                 />
               )}
             </span>
-            {result.isError && !pending && (
-              <span className={styles.errorBadge}>error</span>
-            )}
+            <div className={styles.outputActions}>
+              {result.isError && !pending && (
+                <span className={styles.errorBadge}>error</span>
+              )}
+              <button
+                type="button"
+                className={styles.reset}
+                onClick={() => setCode(initialCode)}
+                aria-label={`Reset ${title} snippet`}
+              >
+                Reset
+              </button>
+            </div>
           </div>
           <pre
             className={`${styles.output} ${result.isError ? styles.outputError : ""}`}

--- a/demo/src/components/ExamplePlayground.tsx
+++ b/demo/src/components/ExamplePlayground.tsx
@@ -13,8 +13,6 @@ import {
   validatePostalCode,
   validatePostalCodes,
 } from "postal-code-checker";
-import { readShareParam } from "../data/share";
-import { ShareButton } from "./ui/ShareButton";
 import styles from "./ExamplePlayground.module.scss";
 
 type RunResult = { output: string; isError: boolean };
@@ -83,19 +81,14 @@ function runSnippet(code: string): RunResult {
 }
 
 type Props = {
-  shareKey: string;
   title: string;
   description?: string;
   initialCode: string;
 };
 
-export function ExamplePlayground({ shareKey, title, description, initialCode }: Props) {
-  const startingCode = useMemo(
-    () => readShareParam(shareKey) ?? initialCode,
-    [shareKey, initialCode],
-  );
-  const [code, setCode] = useState(startingCode);
-  const [result, setResult] = useState<RunResult>(() => runSnippet(startingCode));
+export function ExamplePlayground({ title, description, initialCode }: Props) {
+  const [code, setCode] = useState(initialCode);
+  const [result, setResult] = useState<RunResult>(() => runSnippet(initialCode));
   const [pending, setPending] = useState(false);
   const firstRun = useRef(true);
 
@@ -117,13 +110,6 @@ export function ExamplePlayground({ shareKey, title, description, initialCode }:
 
   return (
     <div className={styles.panel}>
-      <div className={styles.shareCorner}>
-        <ShareButton
-          paramName={shareKey}
-          getValue={() => code}
-          ariaLabel={`Share ${title}`}
-        />
-      </div>
       <div className={styles.header}>
         <div>
           <h3>{title}</h3>

--- a/demo/src/components/Faq.tsx
+++ b/demo/src/components/Faq.tsx
@@ -1,7 +1,20 @@
-import { useState } from "react";
+import { Fragment, useState, type ReactNode } from "react";
 import { FAQS } from "../data/content";
 import { SectionHeading } from "./ui/SectionHeading";
 import styles from "./Faq.module.scss";
+
+// Render inline `backtick` spans as <code>; leave everything else alone.
+// ReactNode values pass through untouched so richer answers still work.
+function renderAnswer(answer: ReactNode): ReactNode {
+  if (typeof answer !== "string") return answer;
+  const parts = answer.split(/(`[^`]+`)/g);
+  return parts.map((part, i) => {
+    if (part.startsWith("`") && part.endsWith("`") && part.length > 1) {
+      return <code key={i}>{part.slice(1, -1)}</code>;
+    }
+    return <Fragment key={i}>{part}</Fragment>;
+  });
+}
 
 export function Faq() {
   const [open, setOpen] = useState<string | null>(FAQS[0]?.id ?? null);
@@ -54,7 +67,7 @@ export function Faq() {
               >
                 <div className={styles.panelInner}>
                   <div className={styles.answer}>
-                    <p>{item.answer}</p>
+                    <p>{renderAnswer(item.answer)}</p>
                   </div>
                 </div>
               </div>

--- a/demo/src/components/FormatPanel.tsx
+++ b/demo/src/components/FormatPanel.tsx
@@ -1,17 +1,45 @@
-import { useMemo, useState } from "react";
+import { useCallback, useMemo, useState } from "react";
 import { format } from "postal-code-checker";
+import { readShareParam } from "../data/share";
 import { CountryCombobox } from "./ui/CountryCombobox";
+import { ShareButton } from "./ui/ShareButton";
 import styles from "./BatchPanel.module.scss";
 
+type Shared = { country: string; input: string };
+
+function loadInitial(): Shared {
+  const raw = readShareParam("format");
+  if (raw) {
+    try {
+      const parsed = JSON.parse(raw) as Partial<Shared>;
+      if (typeof parsed.country === "string" && typeof parsed.input === "string") {
+        return { country: parsed.country, input: parsed.input };
+      }
+    } catch {
+      // fall through to defaults
+    }
+  }
+  return { country: "CA", input: "k1a0t6" };
+}
+
 export function FormatPanel() {
-  const [countryCode, setCountryCode] = useState("CA");
-  const [raw, setRaw] = useState("k1a0t6");
+  const initial = useMemo(loadInitial, []);
+  const [countryCode, setCountryCode] = useState(initial.country);
+  const [raw, setRaw] = useState(initial.input);
 
   const formatted = useMemo(() => format(countryCode, raw), [countryCode, raw]);
   const ok = formatted !== null;
 
+  const getShareValue = useCallback(
+    () => JSON.stringify({ country: countryCode, input: raw }),
+    [countryCode, raw],
+  );
+
   return (
     <div className={styles.panel}>
+      <div className={styles.shareCorner}>
+        <ShareButton paramName="format" getValue={getShareValue} ariaLabel="Share this format example" />
+      </div>
       <div className={styles.header}>
         <div>
           <h3>Canonical formatting</h3>

--- a/demo/src/components/GuessPanel.tsx
+++ b/demo/src/components/GuessPanel.tsx
@@ -1,18 +1,38 @@
-import { useMemo, useState } from "react";
+import { useCallback, useMemo, useState } from "react";
 import { guessCountries } from "postal-code-checker";
+import { readShareParam } from "../data/share";
+import { ShareButton } from "./ui/ShareButton";
 import styles from "./BatchPanel.module.scss";
 
 type Props = {
   onPickCountry?: (code: string) => void;
 };
 
+function loadInitialInput(): string {
+  const raw = readShareParam("guess");
+  if (raw) {
+    try {
+      const parsed = JSON.parse(raw) as { input?: unknown };
+      if (typeof parsed.input === "string") return parsed.input;
+    } catch {
+      // fall through
+    }
+  }
+  return "12345";
+}
+
 export function GuessPanel({ onPickCountry }: Props) {
-  const [raw, setRaw] = useState("12345");
+  const [raw, setRaw] = useState(() => loadInitialInput());
   const matches = useMemo(() => guessCountries(raw), [raw]);
   const hasInput = raw.trim() !== "";
 
+  const getShareValue = useCallback(() => JSON.stringify({ input: raw }), [raw]);
+
   return (
     <div className={styles.panel}>
+      <div className={styles.shareCorner}>
+        <ShareButton paramName="guess" getValue={getShareValue} ariaLabel="Share this guess example" />
+      </div>
       <div className={styles.header}>
         <div>
           <h3>Country guessing</h3>

--- a/demo/src/components/Hero.module.scss
+++ b/demo/src/components/Hero.module.scss
@@ -81,6 +81,14 @@
   box-shadow: var(--shadow-sm);
   min-width: 0;
   overflow: hidden;
+  position: relative;
+}
+
+.shareCorner {
+  position: absolute;
+  top: 14px;
+  right: 14px;
+  z-index: 1;
 }
 
 .cardEyebrow {

--- a/demo/src/components/Hero.tsx
+++ b/demo/src/components/Hero.tsx
@@ -1,11 +1,13 @@
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
   getAllCountries,
   getCountryByCode,
   validatePostalCode,
   type Country,
 } from "postal-code-checker";
+import { readShareParam } from "../data/share";
 import { CountryCombobox } from "./ui/CountryCombobox";
+import { ShareButton } from "./ui/ShareButton";
 import styles from "./Hero.module.scss";
 
 type Verdict = "idle" | "valid" | "invalid" | "none";
@@ -37,14 +39,51 @@ type HeroProps = {
   onCountryChange: (code: string) => void;
 };
 
+type Shared = { country?: string; code?: string };
+
+function loadInitial(): Shared {
+  const raw = readShareParam("hero");
+  if (!raw) return {};
+  try {
+    const parsed = JSON.parse(raw) as Partial<Shared>;
+    return {
+      country: typeof parsed.country === "string" ? parsed.country : undefined,
+      code: typeof parsed.code === "string" ? parsed.code : undefined,
+    };
+  } catch {
+    return {};
+  }
+}
+
 export function Hero({ countryCode, onCountryChange }: HeroProps) {
   const countries = useCountries();
-  const [code, setCode] = useState<string>("");
+  const initial = useMemo(loadInitial, []);
+  const [code, setCode] = useState<string>(initial.code ?? "");
+
+  // When we boot from a shared URL that set a code, the reset effect below
+  // would wipe it on the initial-mount fire (and again when onCountryChange
+  // runs). Track the country we're hydrating into so we can skip that reset.
+  const hydrationTargetRef = useRef<string | null>(
+    initial.code ? (initial.country ?? countryCode) : null,
+  );
 
   const country: Country | null = useMemo(
     () => getCountryByCode(countryCode),
     [countryCode],
   );
+
+  const getShareValue = useCallback(
+    () => JSON.stringify({ country: countryCode, code }),
+    [countryCode, code],
+  );
+
+  useEffect(() => {
+    if (initial.country && initial.country !== countryCode) {
+      onCountryChange(initial.country);
+    }
+    // Only apply shared state on first mount.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   const hasPatterns = (country?.postalCodePatterns.length ?? 0) > 0;
 
@@ -73,7 +112,12 @@ export function Hero({ countryCode, onCountryChange }: HeroProps) {
   }, [country, hasPatterns, code, countryCode]);
 
   // Reset the input whenever the country changes — format almost always differs.
+  // Skip the one change we trigger ourselves to hydrate a shared URL.
   useEffect(() => {
+    if (hydrationTargetRef.current === countryCode) {
+      hydrationTargetRef.current = null;
+      return;
+    }
     setCode("");
   }, [countryCode]);
 
@@ -112,6 +156,13 @@ export function Hero({ countryCode, onCountryChange }: HeroProps) {
       </div>
 
       <div className={styles.card}>
+        <div className={styles.shareCorner}>
+          <ShareButton
+            paramName="hero"
+            getValue={getShareValue}
+            ariaLabel="Share this validator state"
+          />
+        </div>
         <div className={styles.cardEyebrow}>Live validator</div>
         <div className={styles.row}>
           <div>

--- a/demo/src/components/InstallMatrix.module.scss
+++ b/demo/src/components/InstallMatrix.module.scss
@@ -10,6 +10,14 @@
   border-radius: $radius-lg;
   padding: 28px;
   box-shadow: var(--shadow-sm);
+  position: relative;
+}
+
+.shareCorner {
+  position: absolute;
+  top: 14px;
+  right: 14px;
+  z-index: 1;
 }
 
 .header {

--- a/demo/src/components/InstallMatrix.module.scss
+++ b/demo/src/components/InstallMatrix.module.scss
@@ -10,14 +10,13 @@
   border-radius: $radius-lg;
   padding: 28px;
   box-shadow: var(--shadow-sm);
-  position: relative;
 }
 
-.shareCorner {
-  position: absolute;
-  top: 14px;
-  right: 14px;
-  z-index: 1;
+.headerRight {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  flex-wrap: wrap;
 }
 
 .header {

--- a/demo/src/components/InstallMatrix.tsx
+++ b/demo/src/components/InstallMatrix.tsx
@@ -1,22 +1,40 @@
-import { useMemo, useState } from "react";
+import { useCallback, useMemo, useState } from "react";
 import {
   INSTALL_COMMANDS,
   PACKAGE_MANAGERS,
   type PackageManager,
 } from "../data/examples";
+import { readShareParam } from "../data/share";
 import { CodeBlock } from "./ui/CodeBlock";
+import { ShareButton } from "./ui/ShareButton";
 import { Tabs } from "./ui/Tabs";
 import styles from "./InstallMatrix.module.scss";
 
 const TABS = PACKAGE_MANAGERS.map((pm) => ({ id: pm, label: pm }));
 
+function loadInitial(): PackageManager {
+  const raw = readShareParam("install");
+  if (raw && (PACKAGE_MANAGERS as readonly string[]).includes(raw)) {
+    return raw as PackageManager;
+  }
+  return "npm";
+}
+
 export function InstallMatrix() {
-  const [active, setActive] = useState<PackageManager>("npm");
+  const [active, setActive] = useState<PackageManager>(() => loadInitial());
   const code = useMemo(() => INSTALL_COMMANDS[active], [active]);
+  const getShareValue = useCallback(() => active, [active]);
 
   return (
     <section id="install" className={styles.section} aria-labelledby="install-heading">
       <div className={styles.panel}>
+        <div className={styles.shareCorner}>
+          <ShareButton
+            paramName="install"
+            getValue={getShareValue}
+            ariaLabel="Share this install tab"
+          />
+        </div>
         <div className={styles.header}>
           <h2 id="install-heading">Install</h2>
           <Tabs

--- a/demo/src/components/InstallMatrix.tsx
+++ b/demo/src/components/InstallMatrix.tsx
@@ -28,22 +28,22 @@ export function InstallMatrix() {
   return (
     <section id="install" className={styles.section} aria-labelledby="install-heading">
       <div className={styles.panel}>
-        <div className={styles.shareCorner}>
-          <ShareButton
-            paramName="install"
-            getValue={getShareValue}
-            ariaLabel="Share this install tab"
-          />
-        </div>
         <div className={styles.header}>
           <h2 id="install-heading">Install</h2>
-          <Tabs
-            tabs={TABS}
-            active={active}
-            onChange={setActive}
-            variant="pill"
-            ariaLabel="Package manager"
-          />
+          <div className={styles.headerRight}>
+            <Tabs
+              tabs={TABS}
+              active={active}
+              onChange={setActive}
+              variant="pill"
+              ariaLabel="Package manager"
+            />
+            <ShareButton
+              paramName="install"
+              getValue={getShareValue}
+              ariaLabel="Share this install tab"
+            />
+          </div>
         </div>
         <CodeBlock code={code} ariaLabel={`${active} install command`} />
       </div>

--- a/demo/src/components/LiveEditor.tsx
+++ b/demo/src/components/LiveEditor.tsx
@@ -2,7 +2,7 @@ import { ExamplePlayground } from "./ExamplePlayground";
 import styles from "./LiveEditor.module.scss";
 
 type Example = {
-  shareKey: string;
+  id: string;
   title: string;
   description: string;
   code: string;
@@ -10,7 +10,7 @@ type Example = {
 
 const EXAMPLES: Example[] = [
   {
-    shareKey: "ex-validate",
+    id: "validate",
     title: "Validate a single postal code",
     description: "validatePostalCode(countryCode, postalCode) → boolean",
     code: `// Case and surrounding spaces are tolerated.
@@ -22,7 +22,7 @@ console.log(validatePostalCode("US", "NOPE"));
 `,
   },
   {
-    shareKey: "ex-batch",
+    id: "batch",
     title: "Batch validation",
     description: "validatePostalCodes(countryCode, codes[]) — results align with input order",
     code: `const codes = ["K1A 0T6", "90210", "BAD", "H0H 0H0"];
@@ -34,7 +34,7 @@ codes.forEach((code, i) => {
 `,
   },
   {
-    shareKey: "ex-country-lookup",
+    id: "country-lookup",
     title: "Country lookup — alpha-2 and alpha-3",
     description: "getCountryByCode accepts both ISO forms and returns the same record",
     code: `const byAlpha2 = getCountryByCode("DE");
@@ -49,7 +49,7 @@ console.log("examples:", byAlpha2?.examplePostalCodes);
 `,
   },
   {
-    shareKey: "ex-case-whitespace",
+    id: "case-whitespace",
     title: "Case and whitespace tolerance",
     description: "Input is trimmed and uppercased before matching",
     code: `// Lowercase + extra spaces — still valid
@@ -61,7 +61,7 @@ console.log(validatePostalCode("CA", "k1a0t6"));
 `,
   },
   {
-    shareKey: "ex-list-all",
+    id: "list-all",
     title: "List every supported country",
     description: "getAllCountries() → { countryName, countryCode }[]",
     code: `const all = getAllCountries();
@@ -81,8 +81,7 @@ export function LiveEditor() {
     <div className={styles.stack}>
       {EXAMPLES.map((ex) => (
         <ExamplePlayground
-          key={ex.shareKey}
-          shareKey={ex.shareKey}
+          key={ex.id}
           title={ex.title}
           description={ex.description}
           initialCode={ex.code}

--- a/demo/src/components/LiveEditor.tsx
+++ b/demo/src/components/LiveEditor.tsx
@@ -2,6 +2,7 @@ import { ExamplePlayground } from "./ExamplePlayground";
 import styles from "./LiveEditor.module.scss";
 
 type Example = {
+  shareKey: string;
   title: string;
   description: string;
   code: string;
@@ -9,6 +10,7 @@ type Example = {
 
 const EXAMPLES: Example[] = [
   {
+    shareKey: "ex-validate",
     title: "Validate a single postal code",
     description: "validatePostalCode(countryCode, postalCode) → boolean",
     code: `// Case and surrounding spaces are tolerated.
@@ -20,6 +22,7 @@ console.log(validatePostalCode("US", "NOPE"));
 `,
   },
   {
+    shareKey: "ex-batch",
     title: "Batch validation",
     description: "validatePostalCodes(countryCode, codes[]) — results align with input order",
     code: `const codes = ["K1A 0T6", "90210", "BAD", "H0H 0H0"];
@@ -31,6 +34,7 @@ codes.forEach((code, i) => {
 `,
   },
   {
+    shareKey: "ex-country-lookup",
     title: "Country lookup — alpha-2 and alpha-3",
     description: "getCountryByCode accepts both ISO forms and returns the same record",
     code: `const byAlpha2 = getCountryByCode("DE");
@@ -45,6 +49,7 @@ console.log("examples:", byAlpha2?.examplePostalCodes);
 `,
   },
   {
+    shareKey: "ex-case-whitespace",
     title: "Case and whitespace tolerance",
     description: "Input is trimmed and uppercased before matching",
     code: `// Lowercase + extra spaces — still valid
@@ -56,6 +61,7 @@ console.log(validatePostalCode("CA", "k1a0t6"));
 `,
   },
   {
+    shareKey: "ex-list-all",
     title: "List every supported country",
     description: "getAllCountries() → { countryName, countryCode }[]",
     code: `const all = getAllCountries();
@@ -75,7 +81,8 @@ export function LiveEditor() {
     <div className={styles.stack}>
       {EXAMPLES.map((ex) => (
         <ExamplePlayground
-          key={ex.title}
+          key={ex.shareKey}
+          shareKey={ex.shareKey}
           title={ex.title}
           description={ex.description}
           initialCode={ex.code}

--- a/demo/src/components/MigrationGuide.tsx
+++ b/demo/src/components/MigrationGuide.tsx
@@ -46,8 +46,8 @@ export function MigrationGuide() {
       <div className={styles.block}>
         <SectionHeading
           title="usePostalCodeValidation is deprecated"
-          subtitle="The u-prefix tripped React's rules-of-hooks lint for non-React consumers. Still works in 2.x — removal scheduled for 3.0."
-          badge="removal in 3.0"
+          subtitle="The u-prefix tripped React's rules-of-hooks lint for non-React consumers. Still works in 2.x — removal scheduled for 3.0.0."
+          badge="removal in 3.0.0"
         />
         <p className={styles.note}>
           Replace any call to <code>usePostalCodeValidation()(code, postal)</code> with a

--- a/demo/src/components/Navbar.tsx
+++ b/demo/src/components/Navbar.tsx
@@ -1,7 +1,7 @@
 import { ThemeToggle } from "./ThemeToggle";
 import styles from "./Navbar.module.scss";
 
-const VERSION = "2.1.0-alpha.2";
+const VERSION = "2.1.0";
 
 export function Navbar() {
   return (

--- a/demo/src/components/Navbar.tsx
+++ b/demo/src/components/Navbar.tsx
@@ -1,7 +1,7 @@
 import { ThemeToggle } from "./ThemeToggle";
 import styles from "./Navbar.module.scss";
 
-const VERSION = "2.0.1";
+const VERSION = "2.1.0-alpha.2";
 
 export function Navbar() {
   return (

--- a/demo/src/components/Playground.module.scss
+++ b/demo/src/components/Playground.module.scss
@@ -21,6 +21,15 @@
   margin-top: 16px;
 }
 
+.configWrap {
+  margin-top: 40px;
+  scroll-margin-top: 80px;
+}
+
+.configPanelWrap {
+  margin-top: 18px;
+}
+
 .roadmapWrap {
   margin-top: 16px;
 }

--- a/demo/src/components/Playground.tsx
+++ b/demo/src/components/Playground.tsx
@@ -38,7 +38,7 @@ export function Playground({ activeCountry, onPickCountry, searchRef }: Props) {
         <SectionHeading
           title="Configuration"
           subtitle="Layer custom country data on top of the bundled dataset with a single configure() call. Replace an existing country's patterns, or register one the dataset doesn't ship — like Kosovo (XK)."
-          badge="2.1.0-alpha.2"
+          badge="2.1.0"
         />
         <div className={styles.configPanelWrap}>
           <ConfigurationPanel />

--- a/demo/src/components/Playground.tsx
+++ b/demo/src/components/Playground.tsx
@@ -1,5 +1,6 @@
 import { type RefObject } from "react";
 import { BatchPanel } from "./BatchPanel";
+import { ConfigurationPanel } from "./ConfigurationPanel";
 import { DatasetPanel } from "./DatasetPanel";
 import { FormatPanel } from "./FormatPanel";
 import { GuessPanel } from "./GuessPanel";
@@ -32,6 +33,16 @@ export function Playground({ activeCountry, onPickCountry, searchRef }: Props) {
       </div>
       <div className={styles.editorWrap}>
         <LiveEditor />
+      </div>
+      <div id="configuration" className={styles.configWrap}>
+        <SectionHeading
+          title="Configuration"
+          subtitle="Layer custom country data on top of the bundled dataset with a single configure() call. Replace an existing country's patterns, or register one the dataset doesn't ship — like Kosovo (XK)."
+          badge="2.1.0-alpha.2"
+        />
+        <div className={styles.configPanelWrap}>
+          <ConfigurationPanel />
+        </div>
       </div>
       <div className={styles.roadmapWrap}>
         <Roadmap />

--- a/demo/src/components/Roadmap.module.scss
+++ b/demo/src/components/Roadmap.module.scss
@@ -66,9 +66,14 @@
   font-weight: 600;
   letter-spacing: 0.04em;
   text-transform: uppercase;
-  color: var(--color-accent-contrast);
+  color: var(--color-accent);
   background: var(--color-accent-soft);
   border-radius: 999px;
+}
+
+.shipped {
+  color: #fff;
+  background: var(--color-accent);
 }
 
 .title {

--- a/demo/src/components/Roadmap.tsx
+++ b/demo/src/components/Roadmap.tsx
@@ -12,19 +12,26 @@ export function Roadmap() {
         </div>
       </div>
       <ol className={styles.list}>
-        {ROADMAP.map((item) => (
-          <li key={`${item.milestone}-${item.title}`} className={styles.item}>
-            <div className={styles.topRow}>
-              <span className={styles.milestone}>{item.milestone}</span>
-              <h4 className={styles.title}>{item.title}</h4>
-            </div>
-            <p className={styles.desc}>{item.description}</p>
-            <CodeBlock
-              code={item.snippet}
-              ariaLabel={`${item.title} snippet`}
-            />
-          </li>
-        ))}
+        {ROADMAP.map((item) => {
+          const shipped = item.milestone.toLowerCase().startsWith("shipped");
+          return (
+            <li key={`${item.milestone}-${item.title}`} className={styles.item}>
+              <div className={styles.topRow}>
+                <span
+                  className={`${styles.milestone} ${shipped ? styles.shipped : ""}`}
+                >
+                  {item.milestone}
+                </span>
+                <h4 className={styles.title}>{item.title}</h4>
+              </div>
+              <p className={styles.desc}>{item.description}</p>
+              <CodeBlock
+                code={item.snippet}
+                ariaLabel={`${item.title} snippet`}
+              />
+            </li>
+          );
+        })}
       </ol>
     </div>
   );

--- a/demo/src/components/Roadmap.tsx
+++ b/demo/src/components/Roadmap.tsx
@@ -8,7 +8,7 @@ export function Roadmap() {
       <div className={styles.header}>
         <div>
           <h3>What's next</h3>
-          <p>Shipping order for 2.x and 3.0. Feedback welcome on issues.</p>
+          <p>Shipping order for 2.x and 3.0.0. Feedback welcome on issues.</p>
         </div>
       </div>
       <ol className={styles.list}>

--- a/demo/src/components/UseCases.module.scss
+++ b/demo/src/components/UseCases.module.scss
@@ -26,6 +26,9 @@
   display: flex;
   flex-direction: column;
   min-width: 0;
+  position: relative;
+  transition: border-color $duration-base $ease, box-shadow $duration-base $ease;
+  scroll-margin-top: 80px;
 
   h3 {
     margin: 0;
@@ -34,6 +37,18 @@
     letter-spacing: -0.01em;
     color: var(--color-text);
   }
+
+  &.highlight {
+    border-color: var(--color-accent);
+    box-shadow: 0 0 0 3px var(--color-accent-soft);
+  }
+}
+
+.shareCorner {
+  position: absolute;
+  top: 14px;
+  right: 14px;
+  z-index: 1;
 }
 
 .cardHead {
@@ -42,6 +57,7 @@
   justify-content: space-between;
   gap: 12px;
   margin-bottom: 6px;
+  padding-right: 40px;
 }
 
 .tag {

--- a/demo/src/components/UseCases.tsx
+++ b/demo/src/components/UseCases.tsx
@@ -1,5 +1,8 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import { readShareParam } from "../data/share";
 import { SectionHeading } from "./ui/SectionHeading";
 import { CodeBlock } from "./ui/CodeBlock";
+import { ShareButton } from "./ui/ShareButton";
 import styles from "./UseCases.module.scss";
 
 type UseCase = {
@@ -92,7 +95,26 @@ validatePostalCode("usa", "90210");    // true — case-insensitive`,
   },
 ];
 
+function slugify(tag: string): string {
+  return tag.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/(^-|-$)/g, "");
+}
+
 export function UseCases() {
+  const [highlighted, setHighlighted] = useState<string | null>(null);
+  const cardRefs = useRef<Map<string, HTMLElement>>(new Map());
+
+  useEffect(() => {
+    const slug = readShareParam("usecase");
+    if (!slug) return;
+    setHighlighted(slug);
+    const node = cardRefs.current.get(slug);
+    if (node) {
+      node.scrollIntoView({ behavior: "smooth", block: "center" });
+    }
+    const t = window.setTimeout(() => setHighlighted(null), 2400);
+    return () => window.clearTimeout(t);
+  }, []);
+
   return (
     <section
       id="use-cases"
@@ -105,17 +127,53 @@ export function UseCases() {
         subtitle="Five-line drop-ins for the places this package earns its keep."
       />
       <div className={styles.grid}>
-        {USE_CASES.map((uc) => (
-          <article key={uc.title} className={styles.card}>
-            <div className={styles.cardHead}>
-              <h3>{uc.title}</h3>
-              <span className={styles.tag}>{uc.tag}</span>
-            </div>
-            <p className={styles.cardBody}>{uc.description}</p>
-            <CodeBlock code={uc.code} ariaLabel={`${uc.title} snippet`} />
-          </article>
-        ))}
+        {USE_CASES.map((uc) => {
+          const slug = slugify(uc.tag);
+          return (
+            <UseCaseCard
+              key={uc.title}
+              uc={uc}
+              slug={slug}
+              isHighlighted={highlighted === slug}
+              registerRef={(el) => {
+                if (el) cardRefs.current.set(slug, el);
+                else cardRefs.current.delete(slug);
+              }}
+            />
+          );
+        })}
       </div>
     </section>
+  );
+}
+
+type CardProps = {
+  uc: UseCase;
+  slug: string;
+  isHighlighted: boolean;
+  registerRef: (el: HTMLElement | null) => void;
+};
+
+function UseCaseCard({ uc, slug, isHighlighted, registerRef }: CardProps) {
+  const getShareValue = useCallback(() => slug, [slug]);
+  return (
+    <article
+      ref={registerRef}
+      className={`${styles.card} ${isHighlighted ? styles.highlight : ""}`}
+    >
+      <div className={styles.shareCorner}>
+        <ShareButton
+          paramName="usecase"
+          getValue={getShareValue}
+          ariaLabel={`Share ${uc.title}`}
+        />
+      </div>
+      <div className={styles.cardHead}>
+        <h3>{uc.title}</h3>
+        <span className={styles.tag}>{uc.tag}</span>
+      </div>
+      <p className={styles.cardBody}>{uc.description}</p>
+      <CodeBlock code={uc.code} ariaLabel={`${uc.title} snippet`} />
+    </article>
   );
 }

--- a/demo/src/components/WhatsNew.module.scss
+++ b/demo/src/components/WhatsNew.module.scss
@@ -33,7 +33,7 @@
   height: 40px;
   border-radius: $radius;
   background: var(--color-accent-soft);
-  color: var(--color-accent-contrast);
+  color: var(--color-accent);
   display: inline-flex;
   align-items: center;
   justify-content: center;

--- a/demo/src/components/WhatsNew.tsx
+++ b/demo/src/components/WhatsNew.tsx
@@ -8,7 +8,7 @@ export function WhatsNew() {
       <SectionHeading
         headingId="whats-new-heading"
         title="What's new"
-        subtitle="2.1 adds format() and guessCountries() on top of the 2.0 data pipeline rebuilt on Google libaddressinput."
+        subtitle="2.1.0 adds configure(), format() and guessCountries() on top of the 2.0.0 data pipeline rebuilt on Google libaddressinput."
       />
       <div className={styles.grid}>
         {WHATS_NEW.map((item) => (

--- a/demo/src/components/ui/ShareButton.module.scss
+++ b/demo/src/components/ui/ShareButton.module.scss
@@ -35,6 +35,6 @@
 
 .copied {
   background: var(--color-accent-soft);
-  border-color: var(--color-accent-soft);
-  color: var(--color-accent-contrast);
+  border-color: var(--color-accent);
+  color: var(--color-accent);
 }

--- a/demo/src/components/ui/ShareButton.module.scss
+++ b/demo/src/components/ui/ShareButton.module.scss
@@ -1,0 +1,40 @@
+@use "../../styles/variables" as *;
+
+.button {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-family: $font-sans;
+  font-size: 12px;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  padding: 5px 10px;
+  border-radius: $radius;
+  border: 1px solid var(--color-border);
+  background: var(--color-panel-2);
+  color: var(--color-text);
+  cursor: pointer;
+  transition: background $duration-fast $ease, border-color $duration-fast $ease,
+    color $duration-fast $ease;
+
+  &:hover {
+    border-color: var(--color-accent);
+  }
+
+  &:focus-visible {
+    outline: none;
+    border-color: var(--color-accent);
+    box-shadow: 0 0 0 3px var(--color-accent-soft);
+  }
+
+  svg {
+    width: 13px;
+    height: 13px;
+  }
+}
+
+.copied {
+  background: var(--color-accent-soft);
+  border-color: var(--color-accent-soft);
+  color: var(--color-accent-contrast);
+}

--- a/demo/src/components/ui/ShareButton.tsx
+++ b/demo/src/components/ui/ShareButton.tsx
@@ -1,0 +1,67 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import { copyShareUrl } from "../../data/share";
+import styles from "./ShareButton.module.scss";
+
+type Props = {
+  paramName: string;
+  getValue: () => string;
+  ariaLabel?: string;
+};
+
+export function ShareButton({ paramName, getValue, ariaLabel }: Props) {
+  const [copied, setCopied] = useState(false);
+  const timerRef = useRef<number | null>(null);
+
+  useEffect(() => {
+    return () => {
+      if (timerRef.current) window.clearTimeout(timerRef.current);
+    };
+  }, []);
+
+  const handleClick = useCallback(async () => {
+    await copyShareUrl(paramName, getValue());
+    setCopied(true);
+    if (timerRef.current) window.clearTimeout(timerRef.current);
+    timerRef.current = window.setTimeout(() => setCopied(false), 1400);
+  }, [paramName, getValue]);
+
+  return (
+    <button
+      type="button"
+      className={`${styles.button} ${copied ? styles.copied : ""}`}
+      onClick={handleClick}
+      aria-label={ariaLabel ?? "Share — copy link"}
+      title={copied ? "Link copied" : "Copy shareable link"}
+    >
+      {copied ? (
+        <svg
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2.5"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          aria-hidden="true"
+        >
+          <polyline points="20 6 9 17 4 12" />
+        </svg>
+      ) : (
+        <svg
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          aria-hidden="true"
+        >
+          <circle cx="18" cy="5" r="3" />
+          <circle cx="6" cy="12" r="3" />
+          <circle cx="18" cy="19" r="3" />
+          <line x1="8.59" y1="13.51" x2="15.42" y2="17.49" />
+          <line x1="15.41" y1="6.51" x2="8.59" y2="10.49" />
+        </svg>
+      )}
+    </button>
+  );
+}

--- a/demo/src/data/content.ts
+++ b/demo/src/data/content.ts
@@ -63,31 +63,31 @@ export const FAQS: readonly FaqItem[] = [
     id: "source",
     question: "Where does the postal code data come from?",
     answer:
-      "Patterns, examples and country names are sourced from Google's libaddressinput — the same dataset backing Chromium's autofill, Android's address picker and Google Pay. It's Apache-2.0 licensed; attribution lives in NOTICE. We snapshot the dataset at release time rather than calling out to the network at runtime.",
+      "Patterns, examples and country names are sourced from Google's libaddressinput — the same dataset backing Chromium's autofill, Android's address picker and Google Pay. It's Apache-2.0 licensed; attribution lives in `NOTICE`. We snapshot the dataset at release time rather than calling out to the network at runtime.",
   },
   {
     id: "empty",
     question: "Why do some countries show no postal codes?",
     answer:
-      "A handful of countries genuinely have no postal code system — UAE, Zimbabwe, Ireland until 2015, and others. Their entry stores `patterns: []`, and validatePostalCode() returns false for any input against them. This is intentional: it matches the behavior for unknown countries and prevents false positives.",
+      "A handful of countries genuinely have no postal code system — UAE, Zimbabwe, Ireland until 2015, and others. Their entry stores `patterns: []`, and `validatePostalCode()` returns false for any input against them. This is intentional: it matches the behavior for unknown countries and prevents false positives.",
   },
   {
     id: "freshness",
     question: "How up-to-date is the bundled data?",
     answer:
-      "The snapshot date is stamped at the top of src/assets/index.ts on every sync. Maintainer runs `npm run sync:data` before each release; CI blocks publish on drift via `sync:check`. In practice the upstream data changes a few times a year — we pick the delta up on the next cut.",
+      "The snapshot date is stamped at the top of `src/assets/index.ts` on every sync. Maintainer runs `npm run sync:data` before each release; CI blocks publish on drift via `sync:check`. In practice the upstream data changes a few times a year — we pick the delta up on the next cut.",
   },
   {
     id: "custom",
     question: "Can I add custom country patterns?",
     answer:
-      "Yes — since 2.1.0, call `configure({ countries: { ... } })` at app boot. You can add brand-new entries (Kosovo, internal test codes) or replace bundled patterns when your rules are stricter than the defaults. Every utility — validatePostalCode, format, guessCountries, getCountryByCode, getAllCountries — reads from the merged dataset, no per-call wiring. See the Configuration tab above for a runnable example.",
+      "Yes — since 2.1.0, call `configure({ countries: { ... } })` at app boot. You can add brand-new entries (Kosovo, internal test codes) or replace bundled patterns when your rules are stricter than the defaults. Every utility — `validatePostalCode`, `format`, `guessCountries`, `getCountryByCode`, `getAllCountries` — reads from the merged dataset, no per-call wiring. See the Configuration tab above for a runnable example.",
   },
   {
     id: "geo",
     question: "Does this look up cities or do geolocation?",
     answer:
-      "No. This library validates format only — it tells you whether a string could be a valid postal code for a country, not whether it actually resolves to a real address. Subdivision-level classification (postal code → state / region) is planned for v3 using Google's sub_zips prefix data.",
+      "No. This library validates format only — it tells you whether a string could be a valid postal code for a country, not whether it actually resolves to a real address. Subdivision-level classification (postal code → state / region) is planned for v3.0.0 using Google's `sub_zips` prefix data.",
   },
   {
     id: "edge",

--- a/demo/src/data/content.ts
+++ b/demo/src/data/content.ts
@@ -81,7 +81,7 @@ export const FAQS: readonly FaqItem[] = [
     id: "custom",
     question: "Can I add custom country patterns?",
     answer:
-      "Yes — in 2.1, call `configure({ countries: { ... } })` at app boot. You can add brand-new entries (Kosovo, internal test codes) or replace bundled patterns for a country. Every utility — validatePostalCode, format, guessCountries, getCountryByCode, getAllCountries — reads from the merged dataset, no per-call wiring. See the Configuration tab above for a runnable example.",
+      "Yes — since 2.1.0, call `configure({ countries: { ... } })` at app boot. You can add brand-new entries (Kosovo, internal test codes) or replace bundled patterns when your rules are stricter than the defaults. Every utility — validatePostalCode, format, guessCountries, getCountryByCode, getAllCountries — reads from the merged dataset, no per-call wiring. See the Configuration tab above for a runnable example.",
   },
   {
     id: "geo",
@@ -107,7 +107,7 @@ export type RoadmapItem = {
 
 export const ROADMAP: readonly RoadmapItem[] = [
   {
-    milestone: "shipped in 2.1",
+    milestone: "shipped in 2.1.0",
     title: "configure()",
     description: "User-supplied country overrides and brand-new countries. Merge into the bundled dataset once at app boot — every utility picks it up automatically.",
     snippet: `configure({
@@ -120,7 +120,7 @@ export const ROADMAP: readonly RoadmapItem[] = [
 })`,
   },
   {
-    milestone: "v2.2",
+    milestone: "v2.2.0",
     title: "parse()",
     description: "Break a structured code into its parts. UK outward/inward, Brazilian prefix/suffix, etc.",
     snippet: `parse("GB", "SW1A 1AA")
@@ -128,14 +128,14 @@ export const ROADMAP: readonly RoadmapItem[] = [
 //     area: "SW", district: "1A" }`,
   },
   {
-    milestone: "v3",
+    milestone: "v3.0.0",
     title: "Subdivision lookup",
     description: "Resolve a postal code to its state / province / region. Uses Google's sub_zips data.",
     snippet: `classify("US", "95014")
 // → { subdivision: "CA" }`,
   },
   {
-    milestone: "v3",
+    milestone: "v3.0.0",
     title: "createValidator()",
     description: "Per-request / multi-tenant validator instances for SSR and edge runtimes, when singleton configure() isn't a fit.",
     snippet: `const v = createValidator({ countries: { ... } });

--- a/demo/src/data/content.ts
+++ b/demo/src/data/content.ts
@@ -107,19 +107,6 @@ export type RoadmapItem = {
 
 export const ROADMAP: readonly RoadmapItem[] = [
   {
-    milestone: "shipped in 2.1.0",
-    title: "configure()",
-    description: "User-supplied country overrides and brand-new countries. Merge into the bundled dataset once at app boot — every utility picks it up automatically.",
-    snippet: `configure({
-  countries: {
-    XK: { patterns: ["/^[1-7]\\\\d{4}$/"],
-          example: ["10000"],
-          country: "Kosovo",
-          alpha3: "XKX" },
-  },
-})`,
-  },
-  {
     milestone: "v2.2.0",
     title: "parse()",
     description: "Break a structured code into its parts. UK outward/inward, Brazilian prefix/suffix, etc.",

--- a/demo/src/data/content.ts
+++ b/demo/src/data/content.ts
@@ -9,6 +9,12 @@ export type Feature = {
 
 export const WHATS_NEW: readonly Feature[] = [
   {
+    icon: "⚙",
+    title: "configure()",
+    description:
+      "Add your own countries or replace bundled patterns at app boot. One call, module-level singleton — every utility picks it up without per-call wiring.",
+  },
+  {
     icon: "fx",
     title: "format()",
     description:
@@ -75,7 +81,7 @@ export const FAQS: readonly FaqItem[] = [
     id: "custom",
     question: "Can I add custom country patterns?",
     answer:
-      "Not yet — the dataset is read-only in 2.x. A `createValidator({ overrides })` API is on the v3 roadmap for internal / private codes. If you need it sooner, a thin wrapper around validatePostalCode() that checks your own patterns first works well today.",
+      "Yes — in 2.1, call `configure({ countries: { ... } })` at app boot. You can add brand-new entries (Kosovo, internal test codes) or replace bundled patterns for a country. Every utility — validatePostalCode, format, guessCountries, getCountryByCode, getAllCountries — reads from the merged dataset, no per-call wiring. See the Configuration tab above for a runnable example.",
   },
   {
     id: "geo",
@@ -101,6 +107,19 @@ export type RoadmapItem = {
 
 export const ROADMAP: readonly RoadmapItem[] = [
   {
+    milestone: "shipped in 2.1",
+    title: "configure()",
+    description: "User-supplied country overrides and brand-new countries. Merge into the bundled dataset once at app boot — every utility picks it up automatically.",
+    snippet: `configure({
+  countries: {
+    XK: { patterns: ["/^[1-7]\\\\d{4}$/"],
+          example: ["10000"],
+          country: "Kosovo",
+          alpha3: "XKX" },
+  },
+})`,
+  },
+  {
     milestone: "v2.2",
     title: "parse()",
     description: "Break a structured code into its parts. UK outward/inward, Brazilian prefix/suffix, etc.",
@@ -117,11 +136,10 @@ export const ROADMAP: readonly RoadmapItem[] = [
   },
   {
     milestone: "v3",
-    title: "Custom overrides",
-    description: "Merge your own patterns on top of the bundled dataset — for internal / private codes.",
-    snippet: `createValidator({
-  overrides: { X1: { patterns: [...] } }
-})`,
+    title: "createValidator()",
+    description: "Per-request / multi-tenant validator instances for SSR and edge runtimes, when singleton configure() isn't a fit.",
+    snippet: `const v = createValidator({ countries: { ... } });
+v.validate("XK", "10000");`,
   },
 ];
 

--- a/demo/src/data/examples.ts
+++ b/demo/src/data/examples.ts
@@ -173,25 +173,25 @@ validatePostalCode(code, "SW1A 1AA"); // → true`,
 export type PackageManager = "npm" | "yarn" | "pnpm" | "bun";
 
 export const INSTALL_COMMANDS: Record<PackageManager, string> = {
-  npm: `# Stable (recommended)
+  npm: `# Stable (recommended) — 2.0.0
 npm install postal-code-checker
 
-# Opt into the v2 alpha
+# Preview the 2.1.0 alpha (configure() + resetConfig())
 npm install postal-code-checker@next`,
-  yarn: `# Stable (recommended)
+  yarn: `# Stable (recommended) — 2.0.0
 yarn add postal-code-checker
 
-# Opt into the v2 alpha
+# Preview the 2.1.0 alpha (configure() + resetConfig())
 yarn add postal-code-checker@next`,
-  pnpm: `# Stable (recommended)
+  pnpm: `# Stable (recommended) — 2.0.0
 pnpm add postal-code-checker
 
-# Opt into the v2 alpha
+# Preview the 2.1.0 alpha (configure() + resetConfig())
 pnpm add postal-code-checker@next`,
-  bun: `# Stable (recommended)
+  bun: `# Stable (recommended) — 2.0.0
 bun add postal-code-checker
 
-# Opt into the v2 alpha
+# Preview the 2.1.0 alpha (configure() + resetConfig())
 bun add postal-code-checker@next`,
 };
 

--- a/demo/src/data/examples.ts
+++ b/demo/src/data/examples.ts
@@ -173,26 +173,14 @@ validatePostalCode(code, "SW1A 1AA"); // → true`,
 export type PackageManager = "npm" | "yarn" | "pnpm" | "bun";
 
 export const INSTALL_COMMANDS: Record<PackageManager, string> = {
-  npm: `# Stable (recommended) — 2.0.0
-npm install postal-code-checker
-
-# Preview the 2.1.0 alpha (configure() + resetConfig())
-npm install postal-code-checker@next`,
-  yarn: `# Stable (recommended) — 2.0.0
-yarn add postal-code-checker
-
-# Preview the 2.1.0 alpha (configure() + resetConfig())
-yarn add postal-code-checker@next`,
-  pnpm: `# Stable (recommended) — 2.0.0
-pnpm add postal-code-checker
-
-# Preview the 2.1.0 alpha (configure() + resetConfig())
-pnpm add postal-code-checker@next`,
-  bun: `# Stable (recommended) — 2.0.0
-bun add postal-code-checker
-
-# Preview the 2.1.0 alpha (configure() + resetConfig())
-bun add postal-code-checker@next`,
+  npm: `# 2.1.0 — latest
+npm install postal-code-checker`,
+  yarn: `# 2.1.0 — latest
+yarn add postal-code-checker`,
+  pnpm: `# 2.1.0 — latest
+pnpm add postal-code-checker`,
+  bun: `# 2.1.0 — latest
+bun add postal-code-checker`,
 };
 
 export const PACKAGE_MANAGERS: readonly PackageManager[] = ["npm", "yarn", "pnpm", "bun"] as const;

--- a/demo/src/data/sections.ts
+++ b/demo/src/data/sections.ts
@@ -11,6 +11,7 @@ export const SECTIONS: readonly Section[] = [
   { id: "whats-new", label: "What's new" },
   { id: "migration", label: "Migration" },
   { id: "playground", label: "Playground" },
+  { id: "configuration", label: "Configuration" },
   { id: "faq", label: "FAQ" },
 ] as const;
 

--- a/demo/src/data/share.ts
+++ b/demo/src/data/share.ts
@@ -1,0 +1,50 @@
+// Shareable-URL helpers used by every Playground panel.
+//
+// Values are JSON-stringified by the caller, then base64-encoded into a single
+// query parameter (e.g. ?config=<base64>). Query strings are preserved by
+// GitHub Pages (unlike hash fragments, which we also want free for the
+// sidebar's #section anchors), so share links survive the production path
+// `/postal-code-checker/?...#configuration`.
+
+export function encodeShareValue(value: string): string {
+  // unescape/encodeURIComponent dance keeps base64 safe for non-ASCII (e.g.
+  // country names with diacritics in a custom config).
+  return btoa(unescape(encodeURIComponent(value)));
+}
+
+export function decodeShareValue(raw: string): string | null {
+  try {
+    return decodeURIComponent(escape(atob(raw)));
+  } catch {
+    return null;
+  }
+}
+
+export function readShareParam(paramName: string): string | null {
+  if (typeof window === "undefined") return null;
+  const url = new URL(window.location.href);
+  const raw = url.searchParams.get(paramName);
+  if (!raw) return null;
+  return decodeShareValue(raw);
+}
+
+export function buildShareUrl(paramName: string, value: string): string {
+  const url = new URL(window.location.href);
+  url.searchParams.set(paramName, encodeShareValue(value));
+  return url.toString();
+}
+
+export async function copyShareUrl(
+  paramName: string,
+  value: string,
+): Promise<string> {
+  const url = buildShareUrl(paramName, value);
+  history.replaceState(null, "", url);
+  try {
+    await navigator.clipboard.writeText(url);
+  } catch {
+    // Clipboard may be blocked (non-HTTPS, permissions). The URL is still in
+    // the address bar — callers just show the "Link copied" confirmation.
+  }
+  return url;
+}

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -1,0 +1,187 @@
+# Configuration
+
+`postal-code-checker` ships with built-in data for 249 countries sourced from Google's [`libaddressinput`](https://github.com/google/libaddressinput). For most applications that dataset is enough — `validatePostalCode("US", "90210")` just works.
+
+When it isn't enough, `configure()` lets you layer user-supplied country data on top in one call, and every utility in the package honors the override immediately.
+
+## When to use it
+
+- **A country you operate in isn't in the bundled dataset.** Kosovo (`XK`) is the canonical example — it's not in ISO 3166-1, so the upstream source doesn't ship it, but Kosovo has a working 5-digit postal code system and is used as `XK` by most shipping APIs.
+- **Your product needs a different country name.** Upstream spellings like `"Bulgaria (rep.)"` or `"Czech Rep."` may not match your UI copy. Override the entry with your preferred name.
+- **You need stricter or looser patterns.** US ZIP codes bundled as `\d{5}(?:-\d{4})?` accept both 5-digit and 5+4. If your product mandates 5+4 only, replace the US entry with a tighter regex.
+- **Internal or corporate "country" codes.** Some logistics systems use non-ISO codes like `XI` (Northern Ireland, post-Brexit), `XA`, or custom internal identifiers. Register them with `configure()` and they validate alongside real countries.
+
+## Quick example — adding Kosovo
+
+```ts
+import { configure, validatePostalCode, getCountryByCode } from "postal-code-checker";
+
+configure({
+  countries: {
+    XK: {
+      patterns: ["/^(?:[1-7]\\d{4})$/"],
+      example: ["10000", "20000"],
+      country: "Kosovo",
+      alpha3: "XKX",
+    },
+  },
+});
+
+validatePostalCode("XK", "10000");   // → true
+validatePostalCode("XK", "99999");   // → false (out of range)
+validatePostalCode("XKX", "10000");  // → true (alpha-3 resolves)
+
+getCountryByCode("XK")?.countryName; // → "Kosovo"
+```
+
+## How the override interacts with every utility
+
+Once `configure()` is called, all of these read from the merged dataset:
+
+| Utility | Sees the override? |
+| --- | --- |
+| `validatePostalCode` | ✅ |
+| `validatePostalCodes` | ✅ |
+| `getCountryByCode` | ✅ |
+| `getAllCountries` | ✅ (new countries appear in the list) |
+| `guessCountries` | ✅ (custom patterns are matched too) |
+| `format` | ✅ |
+| `usePostalCodeValidation` (deprecated) | ✅ |
+
+No call-site changes required. If existing code imports `validatePostalCode` from the package, it picks up the override automatically.
+
+## Loading config from a JSON file
+
+The shape accepted by `configure()` is pure JSON — no functions or classes — so you can keep it in a separate file and import it.
+
+```json
+// custom-countries.json
+{
+  "countries": {
+    "XK": {
+      "patterns": ["/^(?:[1-7]\\d{4})$/"],
+      "example": ["10000", "20000"],
+      "country": "Kosovo",
+      "alpha3": "XKX"
+    },
+    "US": {
+      "patterns": ["/^(?:\\d{5}-\\d{4})$/"],
+      "example": ["12345-6789"],
+      "country": "United States"
+    }
+  }
+}
+```
+
+```ts
+// In your app bootstrap, once at startup:
+import { configure } from "postal-code-checker";
+import customCountries from "./custom-countries.json";
+
+configure(customCountries);
+```
+
+## Semantics
+
+### Replace per country
+
+Each entry under `countries` **wholesale replaces** the built-in entry for that alpha-2 code. Fields are not merged. If you provide `US`, your patterns become the *only* US patterns — the default `\d{5}(?:-\d{4})?` is gone until you `resetConfig()` or supply it yourself.
+
+This keeps the semantics predictable: looking at your config file, you always know exactly which patterns are active for a given country.
+
+### Idempotent across calls
+
+```ts
+configure({ countries: { XK: kosovoEntry } });
+configure({ countries: { YY: ylandEntry } });
+
+// XK is gone. Each call starts from the bundled defaults and layers the
+// given overrides on top — calls don't accumulate.
+```
+
+If you want multiple overrides active at the same time, pass them all in a single `configure()` call.
+
+### Fail fast
+
+`configure()` validates the supplied config synchronously and throws `ConfigurationError` before touching any state. A bad config can't leave the library in a half-configured state.
+
+```ts
+import { configure, ConfigurationError } from "postal-code-checker";
+
+try {
+  configure(userSuppliedConfig);
+} catch (err) {
+  if (err instanceof ConfigurationError) {
+    // The message names the offending field — surface it to the user
+    console.error(err.message);
+  } else {
+    throw err;
+  }
+}
+```
+
+## `resetConfig()`
+
+```ts
+import { resetConfig } from "postal-code-checker";
+
+resetConfig();
+```
+
+Discards any active `configure()` override and restores the bundled defaults. Primary use cases:
+
+- **Test teardown.** Keeps configurations from leaking between tests.
+  ```ts
+  afterEach(() => {
+    resetConfig();
+  });
+  ```
+- **Scenario switching.** Dev tools or feature-flag-driven UIs that toggle between datasets at runtime.
+- **Hot module reloading.** Reset before re-applying the dev-time config so stale overrides don't accumulate across reloads.
+
+Calling `resetConfig()` without a prior `configure()` is a no-op.
+
+## Runtime validation — what `configure()` checks
+
+Every field is validated and the thrown `ConfigurationError` names the offending field path. Quick reference:
+
+| Rule | Error message |
+| --- | --- |
+| `config` is an object | `"config" must be an object` |
+| `countries` is an object | `"config.countries" must be an object` |
+| Keys are 2-letter uppercase | `"countries.<code>": country code must be a 2-letter uppercase string` |
+| Each entry is an object | `"countries.<code>" must be an object` |
+| `patterns` is an array (empty is allowed — means "no postal code system") | `"countries.<code>.patterns" must be an array of strings` |
+| Each pattern is a string wrapped in slashes (`/^…$/`) | `"countries.<code>.patterns[<i>]" must be a regex wrapped in slashes` |
+| Each pattern is a valid regex | `"countries.<code>.patterns[<i>]" is not a valid regex: …` |
+| `example` is an array of strings | `"countries.<code>.example" must be an array of strings` |
+| `country` is a non-empty string | `"countries.<code>.country" must be a non-empty string` |
+| `alpha3` (if set) is 3-letter uppercase | `"countries.<code>.alpha3" must be a 3-letter uppercase string` |
+
+## Pattern format
+
+Patterns use the same format as the bundled dataset:
+
+- **Wrapped in slashes**: `"/^\\d{5}$/"` — the surrounding `/` characters are required, as they match the in-memory format the validator iterates internally.
+- **Anchored**: start with `^` and end with `$` so the regex matches the entire input, not just a substring.
+- **No flags**: just the pattern. Input normalization (trim + uppercase) happens before matching, so you don't need `/i` for case-insensitivity.
+- **Escaping**: JSON-escape `\` as `\\`. In TypeScript/JavaScript source files you can use `String.raw` to avoid the double-backslash, or write `"/^\\d{5}$/"` as above.
+
+Example patterns:
+
+| Intent | Pattern |
+| --- | --- |
+| 5-digit ZIP | `"/^\\d{5}$/"` |
+| 5-digit or 5+4 ZIP | `"/^\\d{5}(?:-\\d{4})?$/"` |
+| Canadian postal code | `"/^[A-CEGHJKLMNPRSTVXY]\\d[A-Z] ?\\d[A-Z]\\d$/"` |
+| Kosovo (5-digit, first digit 1-7) | `"/^[1-7]\\d{4}$/"` |
+
+## SSR / multi-tenant limitation
+
+`configure()` is a module-level singleton. It matches how `i18next` and most "configure once at app boot" libraries work, and keeps the common-case DX trivial — one call, every downstream consumer is covered.
+
+Per-request configuration (SSR, multi-tenant servers where each tenant needs its own dataset) is **not supported** in this release. If you need it, [open an issue](https://github.com/sashiksu/postal-code-checker/issues/new) describing your use case. A `createValidator()` factory that returns bound, instance-scoped functions is on the roadmap — we're waiting for real demand before designing it.
+
+## Try it live
+
+The [interactive demo](https://sashiksu.github.io/postal-code-checker/) includes a Configuration tab where you can paste in a JSON config and see every utility update in place. Shareable URL, Apply/Reset, and a live diff against the bundled dataset.

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -178,7 +178,7 @@ Example patterns:
 
 ## SSR / multi-tenant limitation
 
-`configure()` is a module-level singleton. It matches how `i18next` and most "configure once at app boot" libraries work, and keeps the common-case DX trivial — one call, every downstream consumer is covered.
+`configure()` is a module-level singleton. Call it once at app boot and every downstream consumer — utilities, React components, server routes — sees the merged dataset without extra wiring.
 
 Per-request configuration (SSR, multi-tenant servers where each tenant needs its own dataset) is **not supported** in this release. If you need it, [open an issue](https://github.com/sashiksu/postal-code-checker/issues/new) describing your use case. A `createValidator()` factory that returns bound, instance-scoped functions is on the roadmap — we're waiting for real demand before designing it.
 

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "prepare": "npm run build",
     "prepublishOnly": "npm test",
     "release": "npm run prettier && npm test && npm run sync:check && npm run build && npm publish --access public",
-    "release:next": "npm run prettier && npm test && npm run sync:check && npm run build && npm publish --access public --tag next"
+    "release:next": "npm run prettier && npm test && npm run build && npm publish --access public --tag next"
   },
   "keywords": [
     "postcode",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "sync:check": "ts-node -P tsconfig.cjs.json scripts/sync-postal-data.ts -- --check",
     "gen:social-preview": "ts-node -P tsconfig.cjs.json scripts/gen-social-preview.ts",
     "prepare": "npm run build",
-    "prepublishOnly": "npm run sync:check && npm test",
+    "prepublishOnly": "npm test",
     "release": "npm run prettier && npm test && npm run sync:check && npm run build && npm publish --access public",
     "release:next": "npm run prettier && npm test && npm run sync:check && npm run build && npm publish --access public --tag next"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "postal-code-checker",
-  "version": "2.1.0-alpha.2",
+  "version": "2.1.0",
   "description": "A package for validating postal codes from various countries.",
   "author": "Sashika Suraweera",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "postal-code-checker",
-  "version": "2.1.0-alpha.1",
+  "version": "2.1.0-alpha.2",
   "description": "A package for validating postal codes from various countries.",
   "author": "Sashika Suraweera",
   "license": "MIT",

--- a/src/__tests__/utils/configure.test.ts
+++ b/src/__tests__/utils/configure.test.ts
@@ -1,0 +1,245 @@
+import { ConfigurationError } from "../../utils/ConfigurationError";
+import { configure } from "../../utils/configure";
+import { format } from "../../utils/format";
+import { getAllCountries } from "../../utils/getAllCountries";
+import { getCountryByCode } from "../../utils/getCountryByCode";
+import { guessCountries } from "../../utils/guessCountries";
+import { resetConfig } from "../../utils/resetConfig";
+import { validatePostalCode } from "../../utils/validatePostalCode";
+import { validatePostalCodes } from "../../utils/validatePostalCodes";
+
+const KOSOVO = {
+  patterns: ["/^(?:[1-7]\\d{4})$/"],
+  example: ["10000", "20000"],
+  country: "Kosovo",
+  alpha3: "XKX",
+};
+
+describe("configure()", () => {
+  afterEach(() => {
+    resetConfig();
+  });
+
+  describe("Adding a brand-new country", () => {
+    it("Should make the new country resolvable via getCountryByCode", () => {
+      configure({ countries: { XK: KOSOVO } });
+
+      const kosovo = getCountryByCode("XK");
+      expect(kosovo).not.toBeNull();
+      expect(kosovo?.countryName).toBe("Kosovo");
+      expect(kosovo?.postalCodePatterns).toEqual(["/^(?:[1-7]\\d{4})$/"]);
+      expect(kosovo?.examplePostalCodes).toEqual(["10000", "20000"]);
+    });
+
+    it("Should resolve the custom alpha-3 code", () => {
+      configure({ countries: { XK: KOSOVO } });
+      const byAlpha3 = getCountryByCode("XKX");
+      expect(byAlpha3?.countryCode).toBe("XK");
+    });
+
+    it("Should validate postal codes for the new country", () => {
+      configure({ countries: { XK: KOSOVO } });
+      expect(validatePostalCode("XK", "10000")).toBe(true);
+      expect(validatePostalCode("XK", "20000")).toBe(true);
+      expect(validatePostalCode("XK", "99999")).toBe(false);
+    });
+
+    it("Should include the new country in getAllCountries()", () => {
+      configure({ countries: { XK: KOSOVO } });
+      const all = getAllCountries();
+      expect(all.find((c) => c.countryCode === "XK")?.countryName).toBe("Kosovo");
+    });
+
+    it("Should surface the new country via guessCountries()", () => {
+      configure({ countries: { XK: KOSOVO } });
+      const matches = guessCountries("10000");
+      expect(matches.find((c) => c.countryCode === "XK")).toBeDefined();
+    });
+
+    it("Should format a valid postal code for the new country", () => {
+      configure({ countries: { XK: KOSOVO } });
+      expect(format("XK", "  10000 ")).toBe("10000");
+      expect(format("XK", "99999")).toBeNull();
+    });
+
+    it("Should honor the new country in batch validation", () => {
+      configure({ countries: { XK: KOSOVO } });
+      expect(validatePostalCodes("XK", ["10000", "99999", "20000"])).toEqual([true, false, true]);
+    });
+  });
+
+  describe("Replacing an existing country", () => {
+    it("Should replace the US pattern with a stricter 5+4 requirement", () => {
+      configure({
+        countries: {
+          US: {
+            patterns: ["/^(?:\\d{5}-\\d{4})$/"],
+            example: ["12345-6789"],
+            country: "United States",
+          },
+        },
+      });
+      expect(validatePostalCode("US", "12345")).toBe(false);
+      expect(validatePostalCode("US", "12345-6789")).toBe(true);
+    });
+
+    it("Should not merge patterns — user patterns wholesale replace defaults", () => {
+      configure({
+        countries: {
+          US: {
+            patterns: ["/^(?:ZIP-\\d{5})$/"],
+            example: ["ZIP-12345"],
+            country: "United States",
+          },
+        },
+      });
+      expect(validatePostalCode("US", "12345")).toBe(false);
+      expect(validatePostalCode("US", "ZIP-12345")).toBe(true);
+    });
+  });
+
+  describe("Idempotent replace across calls", () => {
+    it("Should not accumulate overrides from previous calls", () => {
+      configure({ countries: { XK: KOSOVO } });
+      configure({
+        countries: {
+          YY: {
+            patterns: ["/^(?:Y\\d{3})$/"],
+            example: ["Y123"],
+            country: "Yland",
+          },
+        },
+      });
+
+      expect(getCountryByCode("XK")).toBeNull();
+      expect(getCountryByCode("YY")?.countryName).toBe("Yland");
+    });
+
+    it("Should preserve untouched default countries after override", () => {
+      configure({ countries: { XK: KOSOVO } });
+      expect(validatePostalCode("US", "90210")).toBe(true);
+      expect(validatePostalCode("CA", "K1A 0T6")).toBe(true);
+    });
+  });
+
+  describe("Validation errors", () => {
+    it.each([
+      [null, '"config" must be an object'],
+      [undefined, '"config" must be an object'],
+      ["string", '"config" must be an object'],
+      [123, '"config" must be an object'],
+      [[], '"config" must be an object'],
+    ])("Should reject non-object config: %p", (bad, expected) => {
+      expect(() => configure(bad as never)).toThrow(ConfigurationError);
+      expect(() => configure(bad as never)).toThrow(expected);
+    });
+
+    it("Should reject missing countries key", () => {
+      expect(() => configure({} as never)).toThrow('"config.countries" must be an object');
+    });
+
+    it("Should reject non-uppercase alpha-2 code", () => {
+      expect(() =>
+        configure({
+          countries: {
+            us: { patterns: ["/^\\d{5}$/"], example: [], country: "United States" },
+          },
+        }),
+      ).toThrow(/country code must be a 2-letter uppercase string/);
+    });
+
+    it("Should reject non-string patterns", () => {
+      expect(() =>
+        configure({
+          countries: {
+            XK: { patterns: [123 as unknown as string], example: [], country: "K" },
+          },
+        }),
+      ).toThrow(/must be a regex wrapped in slashes/);
+    });
+
+    it("Should reject unwrapped regex strings", () => {
+      expect(() =>
+        configure({
+          countries: {
+            XK: { patterns: ["^\\d{5}$"], example: [], country: "K" },
+          },
+        }),
+      ).toThrow(/must be a regex wrapped in slashes/);
+    });
+
+    it("Should reject a malformed regex", () => {
+      expect(() =>
+        configure({
+          countries: {
+            XK: { patterns: ["/[/"], example: [], country: "K" },
+          },
+        }),
+      ).toThrow(/is not a valid regex/);
+    });
+
+    it("Should reject non-array example", () => {
+      expect(() =>
+        configure({
+          countries: {
+            XK: {
+              patterns: ["/^\\d{5}$/"],
+              example: "not-an-array" as unknown as string[],
+              country: "K",
+            },
+          },
+        }),
+      ).toThrow(/"countries.XK.example" must be an array of strings/);
+    });
+
+    it("Should reject empty country name", () => {
+      expect(() =>
+        configure({
+          countries: {
+            XK: { patterns: ["/^\\d{5}$/"], example: [], country: "   " },
+          },
+        }),
+      ).toThrow(/"countries.XK.country" must be a non-empty string/);
+    });
+
+    it("Should reject a 2-letter alpha3", () => {
+      expect(() =>
+        configure({
+          countries: {
+            XK: {
+              patterns: ["/^\\d{5}$/"],
+              example: [],
+              country: "Kosovo",
+              alpha3: "XK",
+            },
+          },
+        }),
+      ).toThrow(/"countries.XK.alpha3" must be a 3-letter uppercase string/);
+    });
+
+    it("Should leave active data unchanged when configure throws", () => {
+      const beforeCount = getAllCountries().length;
+      expect(() =>
+        configure({
+          countries: {
+            XK: { patterns: ["bad"], example: [], country: "K" },
+          },
+        }),
+      ).toThrow(ConfigurationError);
+      expect(getAllCountries().length).toBe(beforeCount);
+      expect(getCountryByCode("XK")).toBeNull();
+    });
+  });
+
+  describe("Patterns array semantics", () => {
+    it("Should allow an empty patterns array to declare a country with no postal code system", () => {
+      configure({
+        countries: {
+          XZ: { patterns: [], example: [], country: "Noland" },
+        },
+      });
+      expect(validatePostalCode("XZ", "anything")).toBe(false);
+      expect(getAllCountries().find((c) => c.countryCode === "XZ")?.countryName).toBe("Noland");
+    });
+  });
+});

--- a/src/__tests__/utils/resetConfig.test.ts
+++ b/src/__tests__/utils/resetConfig.test.ts
@@ -1,0 +1,75 @@
+import { COUNTRIES } from "../../assets/index";
+import { configure } from "../../utils/configure";
+import { getAllCountries } from "../../utils/getAllCountries";
+import { getCountryByCode } from "../../utils/getCountryByCode";
+import { resetConfig } from "../../utils/resetConfig";
+import { validatePostalCode } from "../../utils/validatePostalCode";
+
+const KOSOVO = {
+  patterns: ["/^(?:[1-7]\\d{4})$/"],
+  example: ["10000"],
+  country: "Kosovo",
+  alpha3: "XKX",
+};
+
+describe("resetConfig()", () => {
+  afterEach(() => {
+    resetConfig();
+  });
+
+  it("Should be a no-op when no configure() has been called", () => {
+    const beforeCount = Object.keys(COUNTRIES).length;
+    resetConfig();
+    expect(getAllCountries().length).toBe(beforeCount);
+  });
+
+  it("Should discard a previously added custom country", () => {
+    configure({ countries: { XK: KOSOVO } });
+    expect(getCountryByCode("XK")).not.toBeNull();
+
+    resetConfig();
+    expect(getCountryByCode("XK")).toBeNull();
+  });
+
+  it("Should restore a replaced country to its bundled pattern", () => {
+    configure({
+      countries: {
+        US: {
+          patterns: ["/^(?:\\d{5}-\\d{4})$/"],
+          example: ["12345-6789"],
+          country: "United States",
+        },
+      },
+    });
+    expect(validatePostalCode("US", "12345")).toBe(false);
+
+    resetConfig();
+    expect(validatePostalCode("US", "12345")).toBe(true);
+  });
+
+  it("Should discard a custom alpha-3 mapping", () => {
+    configure({ countries: { XK: KOSOVO } });
+    expect(getCountryByCode("XKX")?.countryCode).toBe("XK");
+
+    resetConfig();
+    expect(getCountryByCode("XKX")).toBeNull();
+  });
+
+  it("Should return the country count to the default after reset", () => {
+    const baseline = Object.keys(COUNTRIES).length;
+    configure({
+      countries: {
+        XK: KOSOVO,
+        YY: {
+          patterns: ["/^(?:Y\\d{3})$/"],
+          example: ["Y123"],
+          country: "Yland",
+        },
+      },
+    });
+    expect(getAllCountries().length).toBe(baseline + 2);
+
+    resetConfig();
+    expect(getAllCountries().length).toBe(baseline);
+  });
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,15 +2,20 @@
 export * from "./assets";
 
 // Export types
+export * from "./types/AnyCountryCode";
 export * from "./types/Country";
 export * from "./types/CountryCode";
 export * from "./types/CountryOption";
+export * from "./types/PostalCodeConfig";
 
 // Export utilities
+export * from "./utils/ConfigurationError";
+export * from "./utils/configure";
 export * from "./utils/format";
 export * from "./utils/getAllCountries";
 export * from "./utils/getCountryByCode";
 export * from "./utils/guessCountries";
+export * from "./utils/resetConfig";
 export * from "./utils/validatePostalCode";
 export * from "./utils/validatePostalCodes";
 export * from "./utils/usePostalCodeValidation";

--- a/src/types/AnyCountryCode.ts
+++ b/src/types/AnyCountryCode.ts
@@ -1,0 +1,12 @@
+import { CountryCode } from "./CountryCode";
+
+/**
+ * Country code accepted by utilities that can be overridden via `configure()`.
+ *
+ * Resolves to the known alpha-2 / alpha-3 union **plus** any string, which
+ * accommodates country codes added at runtime through `configure()` (for
+ * example, `"XK"` for Kosovo). The `(string & {})` intersection is a
+ * well-known TypeScript pattern that widens the type to accept any string
+ * while preserving autocomplete for the known union members.
+ */
+export type AnyCountryCode = CountryCode | (string & {});

--- a/src/types/Country.ts
+++ b/src/types/Country.ts
@@ -1,9 +1,9 @@
-import { CountryCode } from "./CountryCode";
+import { AnyCountryCode } from "./AnyCountryCode";
 
 export type Country = {
   postalCodePatterns: string[];
   examplePostalCodes: string[];
   isGenericRegex: boolean;
   countryName: string;
-  countryCode: CountryCode;
+  countryCode: AnyCountryCode;
 };

--- a/src/types/PostalCodeConfig.ts
+++ b/src/types/PostalCodeConfig.ts
@@ -1,0 +1,59 @@
+/**
+ * Shape of a single country entry in a {@link PostalCodeConfig}.
+ *
+ * Mirrors the internal country record but omits the internal `isGenericRegex`
+ * flag — user-supplied entries are never treated as generic fallback.
+ */
+export type CountryConfigEntry = {
+  /**
+   * One or more regular expressions, each wrapped in slashes (e.g. `"/^\\d{5}$/"`).
+   * A postal code is valid if it matches *any* pattern after normalization
+   * (trim + uppercase). Pass an empty array to declare that the country has
+   * no postal code system — validation will return false for every input.
+   */
+  patterns: string[];
+  /**
+   * Example codes that satisfy the patterns. Used by demos and documentation;
+   * not used by the validator. Pass an empty array if you have none.
+   */
+  example: string[];
+  /**
+   * Human-readable country name (e.g. `"Kosovo"`). Returned by
+   * `getCountryByCode` and `getAllCountries` under `countryName`.
+   */
+  country: string;
+  /**
+   * Optional ISO 3166-1 alpha-3 code (e.g. `"XKX"` for Kosovo). When set,
+   * `getCountryByCode` will resolve this alpha-3 value to the entry.
+   * Must be a 3-letter uppercase string.
+   */
+  alpha3?: string;
+};
+
+/**
+ * User-supplied configuration for {@link configure}.
+ *
+ * Each entry under `countries` either replaces a built-in country (when the
+ * key matches an existing alpha-2 code) or adds a brand-new country (when it
+ * doesn't). Replace semantics per country — the full default entry is
+ * swapped, not merged field-by-field.
+ *
+ * @example
+ * ```ts
+ * const config: PostalCodeConfig = {
+ *   countries: {
+ *     XK: {
+ *       patterns: ["/^(?:[1-7]\\d{4})$/"],
+ *       example: ["10000", "20000"],
+ *       country: "Kosovo",
+ *       alpha3: "XKX",
+ *     },
+ *   },
+ * };
+ * ```
+ */
+export type PostalCodeConfig = {
+  countries: {
+    [countryCode: string]: CountryConfigEntry;
+  };
+};

--- a/src/utils/ConfigurationError.ts
+++ b/src/utils/ConfigurationError.ts
@@ -1,0 +1,31 @@
+/**
+ * Thrown by `configure()` when the supplied configuration fails runtime
+ * validation (bad shape, missing fields, malformed regex patterns, etc.).
+ *
+ * Catch this specifically to distinguish user-config problems from other
+ * runtime errors:
+ *
+ * ```ts
+ * try {
+ *   configure(userConfig);
+ * } catch (err) {
+ *   if (err instanceof ConfigurationError) {
+ *     // surface the message to the user; it names the offending field
+ *   } else {
+ *     throw err;
+ *   }
+ * }
+ * ```
+ */
+export class ConfigurationError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "ConfigurationError";
+    // Preserve the original constructor in the stack trace (V8).
+    if (typeof (Error as unknown as { captureStackTrace?: unknown }).captureStackTrace === "function") {
+      (Error as unknown as { captureStackTrace: (t: object, c: Function) => void }).captureStackTrace(this, ConfigurationError);
+    }
+    // Ensure `instanceof` works across down-level compile targets (TS extends-Error gotcha).
+    Object.setPrototypeOf(this, ConfigurationError.prototype);
+  }
+}

--- a/src/utils/ConfigurationError.ts
+++ b/src/utils/ConfigurationError.ts
@@ -21,10 +21,6 @@ export class ConfigurationError extends Error {
   constructor(message: string) {
     super(message);
     this.name = "ConfigurationError";
-    // Preserve the original constructor in the stack trace (V8).
-    if (typeof (Error as unknown as { captureStackTrace?: unknown }).captureStackTrace === "function") {
-      (Error as unknown as { captureStackTrace: (t: object, c: Function) => void }).captureStackTrace(this, ConfigurationError);
-    }
     // Ensure `instanceof` works across down-level compile targets (TS extends-Error gotcha).
     Object.setPrototypeOf(this, ConfigurationError.prototype);
   }

--- a/src/utils/activeData.ts
+++ b/src/utils/activeData.ts
@@ -1,0 +1,50 @@
+import { ALPHA3_TO_ALPHA2 as DEFAULT_ALPHA3_MAP } from "../assets/alpha3Map";
+import { COUNTRIES as DEFAULT_COUNTRIES } from "../assets/index";
+import { PostalCodeData } from "../types/PostalCodeData";
+
+export type ActiveData = {
+  countries: PostalCodeData;
+  alpha3Map: Record<string, string>;
+};
+
+let activeData: ActiveData = {
+  countries: DEFAULT_COUNTRIES,
+  alpha3Map: DEFAULT_ALPHA3_MAP,
+};
+
+/**
+ * Returns the current active country dataset — either the bundled defaults
+ * or the merged result of the most recent `configure()` call.
+ *
+ * Internal. Every user-facing utility that reads country data must go through
+ * this accessor so that `configure()` overrides flow through uniformly.
+ */
+export const getActiveData = (): ActiveData => activeData;
+
+/**
+ * Replaces the active dataset in one shot. Called by `configure()` with the
+ * merged result of (defaults ⊕ user config). Internal.
+ */
+export const setActiveData = (next: ActiveData): void => {
+  activeData = next;
+};
+
+/**
+ * Restores the active dataset to the bundled defaults. Called by
+ * `resetConfig()`. Internal.
+ */
+export const resetActiveData = (): void => {
+  activeData = {
+    countries: DEFAULT_COUNTRIES,
+    alpha3Map: DEFAULT_ALPHA3_MAP,
+  };
+};
+
+/**
+ * Exposed for internal tests — lets assertions compare against the bundled
+ * defaults without reaching into `../assets`.
+ */
+export const getDefaultData = (): ActiveData => ({
+  countries: DEFAULT_COUNTRIES,
+  alpha3Map: DEFAULT_ALPHA3_MAP,
+});

--- a/src/utils/configure.ts
+++ b/src/utils/configure.ts
@@ -1,0 +1,116 @@
+import { ALPHA3_TO_ALPHA2 as DEFAULT_ALPHA3_MAP } from "../assets/alpha3Map";
+import { COUNTRIES as DEFAULT_COUNTRIES } from "../assets/index";
+import { PostalCodeConfig } from "../types/PostalCodeConfig";
+import { PostalCodeData } from "../types/PostalCodeData";
+
+import { ConfigurationError } from "./ConfigurationError";
+import { setActiveData } from "./activeData";
+
+const SLASH_WRAPPED = /^\/.+\/$/;
+const ALPHA2 = /^[A-Z]{2}$/;
+const ALPHA3 = /^[A-Z]{3}$/;
+
+/**
+ * Registers a user-supplied country dataset. Subsequent calls to any
+ * utility (`validatePostalCode`, `getCountryByCode`, `getAllCountries`,
+ * `guessCountries`, `format`, …) read from the merged result.
+ *
+ * Semantics:
+ * - **Replace per country.** Each entry wholesale replaces the built-in
+ *   entry for that alpha-2 code, or adds a new country if the code is
+ *   previously unknown. Fields are not merged.
+ * - **Idempotent across calls.** Each call starts from the bundled defaults
+ *   and layers the given overrides on top. Prior calls are not cumulative.
+ * - **Fail fast.** The configuration is validated synchronously. A shape or
+ *   value error throws {@link ConfigurationError} before any state changes.
+ *
+ * @throws {ConfigurationError} When the configuration is structurally
+ *   invalid. The message names the offending field path.
+ *
+ * @example
+ * ```ts
+ * import { configure } from "postal-code-checker";
+ *
+ * configure({
+ *   countries: {
+ *     XK: {
+ *       patterns: ["/^(?:[1-7]\\d{4})$/"],
+ *       example: ["10000", "20000"],
+ *       country: "Kosovo",
+ *       alpha3: "XKX",
+ *     },
+ *   },
+ * });
+ * ```
+ */
+export const configure = (config: PostalCodeConfig): void => {
+  validateConfig(config);
+
+  const mergedCountries: PostalCodeData = { ...DEFAULT_COUNTRIES };
+  const mergedAlpha3Map: Record<string, string> = { ...DEFAULT_ALPHA3_MAP };
+
+  for (const [code, entry] of Object.entries(config.countries)) {
+    mergedCountries[code] = {
+      patterns: entry.patterns,
+      example: entry.example,
+      country: entry.country,
+      isGenericRegex: false,
+    };
+    if (entry.alpha3) {
+      mergedAlpha3Map[entry.alpha3] = code;
+    }
+  }
+
+  setActiveData({ countries: mergedCountries, alpha3Map: mergedAlpha3Map });
+};
+
+function validateConfig(config: unknown): asserts config is PostalCodeConfig {
+  if (!isPlainObject(config)) {
+    throw new ConfigurationError('"config" must be an object');
+  }
+  const countries = (config as { countries?: unknown }).countries;
+  if (!isPlainObject(countries)) {
+    throw new ConfigurationError('"config.countries" must be an object');
+  }
+
+  for (const [code, entry] of Object.entries(countries as Record<string, unknown>)) {
+    if (!ALPHA2.test(code)) {
+      throw new ConfigurationError(`"countries.${code}": country code must be a 2-letter uppercase string`);
+    }
+    if (!isPlainObject(entry)) {
+      throw new ConfigurationError(`"countries.${code}" must be an object`);
+    }
+    const e = entry as Record<string, unknown>;
+
+    if (!Array.isArray(e.patterns)) {
+      throw new ConfigurationError(`"countries.${code}.patterns" must be an array of strings`);
+    }
+    e.patterns.forEach((pattern, i) => {
+      if (typeof pattern !== "string" || !SLASH_WRAPPED.test(pattern)) {
+        throw new ConfigurationError(
+          `"countries.${code}.patterns[${i}]" must be a regex wrapped in slashes (e.g. "/^\\\\d{5}$/")`,
+        );
+      }
+      try {
+        new RegExp(pattern.slice(1, -1));
+      } catch {
+        throw new ConfigurationError(`"countries.${code}.patterns[${i}]" is not a valid regex: ${pattern}`);
+      }
+    });
+
+    if (!Array.isArray(e.example) || e.example.some((x) => typeof x !== "string")) {
+      throw new ConfigurationError(`"countries.${code}.example" must be an array of strings`);
+    }
+
+    if (typeof e.country !== "string" || e.country.trim() === "") {
+      throw new ConfigurationError(`"countries.${code}.country" must be a non-empty string`);
+    }
+
+    if (e.alpha3 !== undefined && (typeof e.alpha3 !== "string" || !ALPHA3.test(e.alpha3))) {
+      throw new ConfigurationError(`"countries.${code}.alpha3" must be a 3-letter uppercase string`);
+    }
+  }
+}
+
+const isPlainObject = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null && !Array.isArray(value);

--- a/src/utils/format.ts
+++ b/src/utils/format.ts
@@ -1,5 +1,5 @@
+import { AnyCountryCode } from "../types/AnyCountryCode";
 import { Country } from "../types/Country";
-import { CountryCode } from "../types/CountryCode";
 
 import { getCountryByCode } from "./getCountryByCode";
 
@@ -9,9 +9,10 @@ import { getCountryByCode } from "./getCountryByCode";
  *
  * Canonicalization trims surrounding whitespace and uppercases letters — the
  * same normalization `validatePostalCode` applies internally. No country-
- * specific separator insertion is performed.
+ * specific separator insertion is performed. Custom countries registered via
+ * `configure()` are honored.
  *
- * @param {CountryCode} countryCode - The ISO 3166-1 country code (alpha-2 or alpha-3).
+ * @param {AnyCountryCode} countryCode - The ISO 3166-1 country code (alpha-2 or alpha-3).
  * @param {string} postalCode - The postal code to format.
  * @returns {string | null} The canonical postal code if valid, otherwise `null`.
  *
@@ -20,7 +21,7 @@ import { getCountryByCode } from "./getCountryByCode";
  * format("CA", "k1a 0t6");  // "K1A 0T6"
  * format("US", "ABC12");    // null
  */
-export const format = (countryCode: CountryCode, postalCode: string): string | null => {
+export const format = (countryCode: AnyCountryCode, postalCode: string): string | null => {
   const country: Country | null = getCountryByCode(countryCode);
   if (!country) return null;
   if (country.postalCodePatterns.length === 0) return null;

--- a/src/utils/getAllCountries.ts
+++ b/src/utils/getAllCountries.ts
@@ -1,9 +1,10 @@
 import { CountryOption } from "../types/CountryOption";
 
-import { COUNTRIES } from "../assets/index";
+import { getActiveData } from "./activeData";
 
 /**
- * Retrieves all countries as an array of CountryOption objects.
+ * Retrieves all countries as an array of CountryOption objects. Includes any
+ * custom countries registered via `configure()`.
  *
  * @returns {CountryOption[]} An array of CountryOption objects, each containing:
  *   - countryName: The name of the country
@@ -18,7 +19,8 @@ import { COUNTRIES } from "../assets/index";
  * // ]
  */
 export const getAllCountries = (): CountryOption[] => {
-  return Object.entries(COUNTRIES).map(([code, country]) => ({
+  const { countries } = getActiveData();
+  return Object.entries(countries).map(([code, country]) => ({
     countryName: country.country,
     countryCode: code.toString(),
   }));

--- a/src/utils/getCountryByCode.ts
+++ b/src/utils/getCountryByCode.ts
@@ -1,16 +1,16 @@
+import { AnyCountryCode } from "../types/AnyCountryCode";
 import { Country } from "../types/Country";
 
-import { ALPHA3_TO_ALPHA2 } from "../assets/alpha3Map";
-import { COUNTRIES } from "../assets/index";
-import { CountryCode } from "../types/CountryCode";
+import { getActiveData } from "./activeData";
 
 /**
  * Retrieves country information based on the provided country code.
  *
  * Accepts ISO 3166-1 alpha-2 (`"US"`) and alpha-3 (`"USA"`) codes, as well
- * as lowercase variants (`"us"`, `"usa"`).
+ * as lowercase variants (`"us"`, `"usa"`). Custom codes registered via
+ * `configure()` are also resolvable.
  *
- * @param {CountryCode} countryCode - ISO 3166-1 alpha-2 or alpha-3 country code.
+ * @param {AnyCountryCode} countryCode - ISO 3166-1 alpha-2 or alpha-3 country code.
  * @returns {Country | null} Country information if found, or null.
  *
  * @example
@@ -18,11 +18,12 @@ import { CountryCode } from "../types/CountryCode";
  * getCountryByCode('USA');  // → same as above (alpha-3 resolved to alpha-2)
  * getCountryByCode('us');   // → same as above (case-insensitive)
  */
-export const getCountryByCode = (countryCode: CountryCode): Country | null => {
+export const getCountryByCode = (countryCode: AnyCountryCode): Country | null => {
+  const { countries, alpha3Map } = getActiveData();
   const upper = countryCode.toUpperCase();
-  const alpha2 = upper.length === 3 ? ALPHA3_TO_ALPHA2[upper] : upper;
+  const alpha2 = upper.length === 3 ? alpha3Map[upper] : upper;
   if (!alpha2) return null;
-  const country = COUNTRIES[alpha2];
+  const country = countries[alpha2];
   return country
     ? {
         postalCodePatterns: country.patterns,

--- a/src/utils/guessCountries.ts
+++ b/src/utils/guessCountries.ts
@@ -1,9 +1,11 @@
-import { COUNTRIES } from "../assets/index";
 import { CountryOption } from "../types/CountryOption";
+
+import { getActiveData } from "./activeData";
 
 /**
  * Given a postal code with no country context, returns every country whose
- * postal code pattern accepts the input.
+ * postal code pattern accepts the input. Honors custom countries registered
+ * via `configure()`.
  *
  * Input is normalized before matching: surrounding whitespace is trimmed and
  * letters are uppercased. Countries with no postal code system are skipped.
@@ -22,8 +24,9 @@ export const guessCountries = (postalCode: string): CountryOption[] => {
   const normalized = postalCode.trim().toUpperCase();
   if (normalized === "") return [];
 
+  const { countries } = getActiveData();
   const matches: CountryOption[] = [];
-  for (const [code, country] of Object.entries(COUNTRIES)) {
+  for (const [code, country] of Object.entries(countries)) {
     if (country.patterns.length === 0) continue;
     const hit = country.patterns.some((wrapped) => {
       const pattern = wrapped.slice(1, -1);

--- a/src/utils/resetConfig.ts
+++ b/src/utils/resetConfig.ts
@@ -1,0 +1,19 @@
+import { resetActiveData } from "./activeData";
+
+/**
+ * Discards any active `configure()` overrides and restores the bundled
+ * default dataset.
+ *
+ * Primary use cases:
+ * - **Test teardown.** `afterEach(resetConfig)` keeps configurations from
+ *   leaking between tests.
+ * - **Scenario switching.** Demos or feature-flag-driven UIs that swap
+ *   datasets at runtime can reset before applying a new config.
+ * - **Hot module reloading.** Reset before re-applying the dev-time config
+ *   so stale overrides don't accumulate.
+ *
+ * Calling `resetConfig()` without a prior `configure()` is a no-op.
+ */
+export const resetConfig = (): void => {
+  resetActiveData();
+};

--- a/src/utils/usePostalCodeValidation.ts
+++ b/src/utils/usePostalCodeValidation.ts
@@ -1,4 +1,4 @@
-import { CountryCode } from "../types/CountryCode";
+import { AnyCountryCode } from "../types/AnyCountryCode";
 
 import { validatePostalCode } from "./validatePostalCode";
 
@@ -19,7 +19,7 @@ import { validatePostalCode } from "./validatePostalCode";
  */
 export const usePostalCodeValidation = () => {
   return {
-    validatePostalCode: (countryCode: CountryCode, postalCode: string): boolean =>
+    validatePostalCode: (countryCode: AnyCountryCode, postalCode: string): boolean =>
       validatePostalCode(countryCode, postalCode),
   };
 };

--- a/src/utils/validatePostalCode.ts
+++ b/src/utils/validatePostalCode.ts
@@ -1,5 +1,5 @@
+import { AnyCountryCode } from "../types/AnyCountryCode";
 import { Country } from "../types/Country";
-import { CountryCode } from "../types/CountryCode";
 
 import { getCountryByCode } from "./getCountryByCode";
 
@@ -8,9 +8,10 @@ import { getCountryByCode } from "./getCountryByCode";
  *
  * Input is normalized before validation: surrounding whitespace is trimmed
  * and letters are uppercased, so `"  k1a 0t6  "` and `"K1A 0T6"` are
- * treated identically.
+ * treated identically. Custom countries registered via `configure()` are
+ * validated the same way.
  *
- * @param {CountryCode} countryCode - The ISO 3166-1 country code (alpha-2 or alpha-3).
+ * @param {AnyCountryCode} countryCode - The ISO 3166-1 country code (alpha-2 or alpha-3).
  * @param {string} postalCode - The postal code to validate.
  * @returns {boolean} True if the postal code is valid for the given country, false otherwise.
  *
@@ -19,7 +20,7 @@ import { getCountryByCode } from "./getCountryByCode";
  * validatePostalCode("CA", "K1A 0T6"); // true
  * validatePostalCode("CA", "k1a 0t6"); // true (case-insensitive)
  */
-export const validatePostalCode = (countryCode: CountryCode, postalCode: string): boolean => {
+export const validatePostalCode = (countryCode: AnyCountryCode, postalCode: string): boolean => {
   const country: Country | null = getCountryByCode(countryCode);
   if (!country) return false;
   if (country.postalCodePatterns.length === 0) return false;

--- a/src/utils/validatePostalCodes.ts
+++ b/src/utils/validatePostalCodes.ts
@@ -1,4 +1,4 @@
-import { CountryCode } from "../types/CountryCode";
+import { AnyCountryCode } from "../types/AnyCountryCode";
 
 import { validatePostalCode } from "./validatePostalCode";
 
@@ -6,9 +6,10 @@ import { validatePostalCode } from "./validatePostalCode";
  * Validates an array of postal codes against a single country.
  *
  * Useful for CSV imports, bulk address validation, and form arrays where
- * many codes share the same country.
+ * many codes share the same country. Custom countries registered via
+ * `configure()` are honored.
  *
- * @param {CountryCode} countryCode - The ISO 3166-1 country code (alpha-2 or alpha-3).
+ * @param {AnyCountryCode} countryCode - The ISO 3166-1 country code (alpha-2 or alpha-3).
  * @param {string[]} postalCodes - Postal codes to validate.
  * @returns {boolean[]} Array of validation results, index-aligned with `postalCodes`.
  *
@@ -16,5 +17,5 @@ import { validatePostalCode } from "./validatePostalCode";
  * validatePostalCodes("US", ["12345", "90210", "abc"]);
  * // → [true, true, false]
  */
-export const validatePostalCodes = (countryCode: CountryCode, postalCodes: string[]): boolean[] =>
+export const validatePostalCodes = (countryCode: AnyCountryCode, postalCodes: string[]): boolean[] =>
   postalCodes.map((code) => validatePostalCode(countryCode, code));


### PR DESCRIPTION
## Summary

Ships three new public APIs on top of 2.0's Google `libaddressinput` dataset:

- **`format(countryCode, postalCode)`** → canonical storable form (trimmed, uppercased), `null` when the input doesn't match the country's pattern.
- **`guessCountries(postalCode)`** → every country whose pattern accepts the input, sorted alphabetically, ready to render as a picker.
- **`configure(config)` + `resetConfig()` + `ConfigurationError`** → user-supplied country overrides and brand-new countries via a single module-level call. Every utility (`validatePostalCode`, `validatePostalCodes`, `getCountryByCode`, `getAllCountries`, `guessCountries`, `format`) reads through the merged dataset automatically — no call-site changes.

Backward-compatible with 2.0; no migration needed. SSR / multi-tenant is explicitly out of scope for `configure()` — deferring `createValidator()` until there's real demand.

Full release notes: [`CHANGELOG.md`](./CHANGELOG.md#210)

## What's in this PR

- Entire alpha cycle (alpha.1 + alpha.2) rolled into a single `[2.1.0]` CHANGELOG entry (per playbook §3 GA convention).
- `package.json` bumped `2.1.0-alpha.2` → `2.1.0`.
- Demo: version badge/navbar flipped off `-alpha.2`, install snippets dropped the `@next` preview blocks, `configure()` removed from the "What's next" roadmap panel.
- README: live-demo CTA promoted under the hero, GIF resized to stop stretching, badge restyled with an orange accent.

## Test plan

- [ ] CI green on this PR
- [ ] `npm test` locally (2.7k+ country-matrix snapshot + unit tests)
- [ ] Post-merge: `npm run release` → `npm publish --access public --ignore-scripts --otp=<code>`
- [ ] Tag `v2.1.0` on master and push
- [ ] Drop `next` dist-tag once GA is on `latest` (`npm dist-tag rm postal-code-checker next`)
- [ ] Pages deploy of the GA demo completes cleanly