### PR TITLE
Make the test workflow actually run, and declare the Node baseline

### DIFF
--- a/.github/workflows/Unit Test Automation.yml
+++ b/.github/workflows/Unit Test Automation.yml
@@ -3,7 +3,10 @@ name: Run Tests
 on:
   pull_request:
     branches:
-      - develop
+      - master
+  push:
+    branches:
+      - master
 
 permissions:
   contents: read
@@ -12,29 +15,31 @@ jobs:
   test:
     runs-on: ubuntu-latest
 
+    strategy:
+      fail-fast: false
+      matrix:
+        # Matches the engines.node baseline declared in package.json.
+        node-version: ["18.x", "20.x", "22.x"]
+
+    name: test (node ${{ matrix.node-version }})
+
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
-      - name: Use Node.js
-        uses: actions/setup-node@v2
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v4
         with:
-          node-version: "20"
-
-      - name: Debug - List directory contents
-        run: ls -la
-
-      - name: Debug - Display package.json content
-        run: cat package.json
+          node-version: ${{ matrix.node-version }}
+          cache: npm
 
       - name: Install dependencies
         run: npm ci
 
+      - name: Lint
+        run: npm run lint
+
       - name: Run tests
         run: npm test
 
-      - name: Upload test results
-        uses: actions/upload-artifact@v2
-        if: failure()
-        with:
-          name: test-results
-          path: test-results
+      - name: Build
+        run: npm run build

--- a/package.json
+++ b/package.json
@@ -21,6 +21,9 @@
     "./package.json": "./package.json"
   },
   "sideEffects": false,
+  "engines": {
+    "node": ">=18"
+  },
   "files": [
     "dist/index.cjs.js",
     "dist/index.mjs",


### PR DESCRIPTION
The test workflow has **never run** — not once, across the entire 1.x and 2.x line.

## The bug

```yaml
on:
  pull_request:
    branches:
      - develop     # ← this branch has never existed in this repo
```

Branches here are `master` + `feature/*` / `bugfix/*` / `release/*`. There is no `develop`, so the trigger never matched. This surfaced on #50, where `gh pr checks` returned only CodeQL — no test run.

Consequence: **every release through 2.2.0 was gated by local test runs only.**

## It was broken anyway

Even had it fired, it would have failed:

- `actions/upload-artifact@v2` — [disabled by GitHub in January 2025](https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/). Any run reaching that step errors out.
- …and it pointed at a `test-results` directory Jest never produces.
- `actions/checkout@v2` and `actions/setup-node@v2` are both deprecated (Node 12/16 runtimes).

## Changes

- **Trigger**: `develop` → `master`, plus `push` to `master` so a bad merge surfaces immediately.
- **Actions**: `checkout@v4`, `setup-node@v4`, npm caching enabled.
- **Removed**: the dead `upload-artifact` step and two debug steps that `ls -la` + `cat package.json`.
- **Added**: `npm run lint` and `npm run build` alongside `npm test`.
- **Matrix**: Node 18 / 20 / 22.
- **`engines.node: ">=18"`** — `CLAUDE.md` documented a Node 18+ baseline "declared via `engines.node`", but the field was never actually present, so the floor was neither enforced nor tested.

## Verification

Local, on this branch:

| Check | Result |
|---|---|
| `npm run lint` | ✅ clean |
| `npm test` | ✅ 2,831 passed |
| Workflow YAML parses | ✅ triggers `{pull_request: [master], push: [master]}` |

The real proof is this PR itself: **the test matrix should now appear in its own checks**, which is exactly what #50 could not do.