### PR TITLE
[DO NOT MERGE] probe: verify CI gate blocks failing tests

### DIFF
--- a/src/__tests__/ci-gate-probe.test.ts
+++ b/src/__tests__/ci-gate-probe.test.ts
@@ -1,0 +1,6 @@
+// Temporary probe: asserts something false to confirm CI blocks merges.
+describe("ci gate probe", () => {
+  it("deliberately fails", () => {
+    expect(1).toBe(2);
+  });
+});


### PR DESCRIPTION
Temporary. Contains a deliberately failing test to confirm required status checks block the merge. Will be closed and deleted immediately.